### PR TITLE
feat(ISV-6369): add linting and GH actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.4'
+        cache: true
+
+    - name: Install Mage
+      run: go install github.com/magefile/mage@latest
+
+    - name: Download dependencies
+      run: mage tidy
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: GoReleaser Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set Up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.4"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: release --clean

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.4'
+        cache: true
+
+    - name: Install Mage
+      run: go install github.com/magefile/mage@latest
+
+    - name: Download dependencies
+      run: mage tidy
+
+    - name: Run tests
+      run: mage test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,9 @@
 ---
 version: "2"
+run:
+  # Use the same build tags that are used in go.mod
+  build-tags:
+    - exclude_graphdriver_btrfs
 linters:
   # https://golangci-lint.run/docs/linters/
   default: standard

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+---
+version: "2"
+linters:
+  # https://golangci-lint.run/docs/linters/
+  default: standard
+  enable:
+    - decorder
+    - err113
+    - gocognit
+    - lll
+    - makezero
+    - modernize
+    - paralleltest
+    - tparallel
+    - prealloc
+    - wrapcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
 ---
 version: "2"
 run:
-  # Use the same build tags that are used in go.mod
+  # Use the same build tags that are used in magefile.go
   build-tags:
     - exclude_graphdriver_btrfs
 linters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,9 +20,6 @@ builds:
       - ppc64le
     goarm:
       - "7"
-    ignore:
-      - goos: darwin
-        goarch: ppc64le
     tags:
       - exclude_graphdriver_btrfs
     hooks:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: capo
+    binary: capo
+    dir: ./cmd/capo
+    ldflags:
+      - -extldflags "-static" -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - ppc64le
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: ppc64le
+    tags:
+      - exclude_graphdriver_btrfs
+    hooks:
+      post:
+        - upx -9 "{{ .Path }}"
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    wrap_in_directory: true
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}--checksums.txt"
+
+release:
+  draft: false
+
+changelog:
+  sort: asc
+  filters:
+    include:
+      - "^feat"
+      - "^fix"
+      - "^chore"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ builds:
     binary: capo
     dir: ./cmd/capo
     ldflags:
-      - -extldflags "-static" -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
+      - -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -18,8 +18,6 @@ builds:
       - amd64
       - arm64
       - ppc64le
-    goarm:
-      - "7"
     tags:
       - exclude_graphdriver_btrfs
     hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2022 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ install it:
 ```sh
 go install github.com/magefile/mage@latest
 ```
+
+The project also uses
+[golangci-lint](https://github.com/golangci/golangci-lint) to run linters:
+```sh
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.6.1
+mage lint
+```

--- a/cmd/capo/main.go
+++ b/cmd/capo/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/konflux-ci/capo/pkg"
@@ -81,7 +82,24 @@ func buildOptsFromArgs(args args) containerfile.BuildOptions {
 	}
 }
 
+func logRevision() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				log.Printf("Capo was built from revision %q", s.Value)
+				return
+			}
+		}
+		// vcs.revision is only available after build, "go run" isn't enough
+		log.Println("Could not find key vcs.revision in build information")
+	} else {
+		log.Println("Could not read capo build information")
+	}
+}
+
 func main() {
+	logRevision()
+
 	args, err := parseArgs()
 	if err != nil {
 		log.Fatalf("%v", err)

--- a/cmd/capo/main.go
+++ b/cmd/capo/main.go
@@ -42,11 +42,8 @@ func parseArgs() (args, error) {
 		"Build argument passed to buildah in the form KEY=VALUE. Can be used multiple times.",
 		func(s string) error {
 			parts := strings.Split(s, "=")
-			if len(parts) != 2 {
+			if len(parts) != 2  || parts[0] == ""{
 				return ErrBuildArg
-			}
-			if parts[0] == "" {
-				return fmt.Errorf("Missing key in build arg for %s.", s)
 			}
 			buildArgs[parts[0]] = parts[1]
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,3 @@
-//go:build exclude_graphdriver_btrfs
 module github.com/konflux-ci/capo
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -279,4 +279,5 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
+// WARNING: when changing, make sure to grep the version number in CI
 go 1.24.4

--- a/magefile.go
+++ b/magefile.go
@@ -65,6 +65,8 @@ func IntegrationTest() error {
 	return sh.RunV("buildah", "unshare", "go", "test", "-v", "-tags=integration", "./pkg")
 }
 
+// Creates a new git tag with the specified version and pushes it to origin.
+// Github CI automation then builds the binary and creates a release.
 func Release(version string) error {
 	sh.RunV("git", "tag", version)
 	sh.RunV("git", "push", "origin", version)

--- a/magefile.go
+++ b/magefile.go
@@ -36,7 +36,7 @@ func Build() error {
 
 // Runs unit tests using Ginkgo.
 func Test() error {
-	return sh.RunV("go", "test", "-tags=unit", "./...")
+	return sh.RunV("go", "test", "-tags=unit,exclude_graphdriver_btrfs", "./...")
 }
 
 // Runs the dlv debugger in a buildah namespace using 'buildah unshare'.

--- a/magefile.go
+++ b/magefile.go
@@ -60,16 +60,13 @@ func Lint() error {
 	return sh.RunV("golangci-lint", "run")
 }
 
-// Runs checks on the code and creates the specified git tag.
-//func Release(ctx context.Context, version string) error {
-//	mg.Deps(Build, Vet, Tidy, Test)
-//
-//	// TODO: restrict to 'main' branch
-//
-//	sh.Run("git", "commit")
-//}
-
 // Builds all test images and runs the integration test.
 func IntegrationTest() error {
 	return sh.RunV("buildah", "unshare", "go", "test", "-v", "-tags=integration", "./pkg")
+}
+
+func Release(version string) error {
+	sh.RunV("git", "tag", version)
+	sh.RunV("git", "push", "origin", version)
+	return nil
 }

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -1,6 +1,7 @@
 package containerfile
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -42,29 +43,18 @@ type BuildOptions struct {
 	Target string
 }
 
-// Error returned by Parse when the Containerfile contains ambiguous relative paths
-// such as relative WORKDIR commands without a previous absolute command or
-// COPY destinations with relative paths.
-type WorkdirError struct {
-	// The original Containerfile command that caused the error
-	command string
-}
-
-func (e *WorkdirError) Error() string {
-	return fmt.Sprintf(
-		"containerfile uses a relative path in a context where the WORKDIR is not manually set: %s",
-		e.command,
-	)
-}
+var ErrTargetNotFound = errors.New("specified target stage was not found in the containerfile")
+var ErrAmbiguousRelativePath = errors.New("relative path in containerfile is ambiguous")
+var ErrParse = errors.New("error while parsing containerfile")
 
 // Parse reads a Containerfile from the passed reader and uses the passed
 // BuildOptions to parse the Containerfile into stages.
 func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
-	var res []Stage
+	res := make([]Stage, 0)
 
 	node, err := imagebuilder.ParseDockerfile(reader)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrParse, err)
 	}
 
 	// TODO: At this stage, Buildah code takes into account OS and ARCH CLI args
@@ -77,13 +67,13 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 	builder := imagebuilder.NewBuilder(opts.Args)
 	rawStages, err := imagebuilder.NewStages(node, builder)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrParse, err)
 	}
 
 	if opts.Target != "" {
 		stagesTargeted, ok := rawStages.ThroughTarget(opts.Target)
 		if !ok {
-			return nil, fmt.Errorf("the target %q was not found in the provided Containerfile", opts.Target)
+			return nil, fmt.Errorf("%w: %s", ErrTargetNotFound, opts.Target)
 		}
 		rawStages = stagesTargeted
 	}
@@ -173,7 +163,7 @@ func getBuilderCopiesInStage(s imagebuilder.Stage) ([]Copy, error) {
 				// if the path is relative, it is relative to the last set workdir
 				// so we need to fail if a WORKDIR command was not yet specified
 				if workdir == "" {
-					return copies, &WorkdirError{child.Original}
+					return copies, fmt.Errorf("%w: %q", ErrAmbiguousRelativePath, child.Original)
 				}
 
 				workdir = filepath.Join(workdir, dirPath)
@@ -214,11 +204,7 @@ func parseCopy(node *parser.Node, workdir string, env []string) (*Copy, error) {
 		// aggregate the COPY arguments by iterating the nodes
 		args := make([]string, 0)
 		curr := node.Next
-		for {
-			if curr == nil {
-				break
-			}
-
+		for curr != nil {
 			args = append(args, curr.Value)
 			curr = curr.Next
 		}
@@ -229,7 +215,8 @@ func parseCopy(node *parser.Node, workdir string, env []string) (*Copy, error) {
 		// resolve relative paths
 		if !filepath.IsAbs(destination) {
 			if workdir == "" {
-				return nil, &WorkdirError{node.Original}
+				return nil, fmt.Errorf("%w: %q", ErrAmbiguousRelativePath, node.Original)
+
 			}
 
 			_, destFile := filepath.Split(destination)

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -72,9 +72,8 @@ func TestParseInvalidRelativePaths(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			reader := strings.NewReader(test.containerfile)
-			var we *WorkdirError
 			_, err := Parse(reader, BuildOptions{})
-			if !errors.As(err, &we) {
+			if !errors.Is(err, ErrAmbiguousRelativePath) {
 				t.Fatalf("Parse didn't return WorkdirError when expected, actual: %v", err)
 			}
 		})

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -1,6 +1,7 @@
 package capo
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -53,20 +54,22 @@ type PackageMetadataItem struct {
 	StageAlias string `json:"stage_alias,omitempty"`
 }
 
+var ErrStorageSetup = errors.New("error while setting up buildah storage")
+
 func SetupStore() (storage.Store, error) {
 	// The containers/storage library requires this to run for some operations
 	if reexec.Init() {
-		return nil, fmt.Errorf("Failed to init reexec during containers/storage setup.")
+		return nil, fmt.Errorf("%w: failed to init reexec", ErrStorageSetup)
 	}
 
 	opts, err := storage.DefaultStoreOptions()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create default container/storage options.")
+		return nil, fmt.Errorf("%w: failed to create default storage options: %w", ErrStorageSetup, err)
 	}
 
 	store, err := storage.GetStore(opts)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create default container/storage store.")
+		return nil, fmt.Errorf("%w: failed to create storage: %w", ErrStorageSetup, err)
 	}
 
 	return store, nil
@@ -79,7 +82,9 @@ func SetupStore() (storage.Store, error) {
 func Scan(
 	stages []containerfile.Stage,
 ) (PackageMetadata, error) {
-	var res PackageMetadata
+	res := PackageMetadata{
+		Packages: make([]PackageMetadataItem, 0),
+	}
 
 	store, err := SetupStore()
 	if err != nil {
@@ -89,7 +94,7 @@ func Scan(
 	for _, pkgSource := range getPackageSources(stages) {
 		stagePkgItems, err := scanSource(store, pkgSource)
 		if err != nil {
-			return PackageMetadata{}, fmt.Errorf("Failed to scan source %+v with error: %v.", pkgSource, err)
+			return PackageMetadata{}, fmt.Errorf("failed to scan source %+v with error: %w", pkgSource, err)
 		}
 
 		res.Packages = append(res.Packages, stagePkgItems...)
@@ -101,7 +106,7 @@ func Scan(
 // getPackageSources uses the passed containerfile stages and returns a slice of
 // packageSource structs, specifying which COPY-ied content originates from which builder stage.
 func getPackageSources(stages []containerfile.Stage) []packageSource {
-	var res []packageSource
+	res := make([]packageSource, 0)
 	aliasToStage := make(map[string]*containerfile.Stage)
 
 	// use index iteration to get consistent references to stages
@@ -197,17 +202,17 @@ func traceSource(
 // scanSource uses the passed initialized storage.Store struct to syft scan content
 // from the passed packageSource. Returns a slice of PackageMetadataItem structs specifying
 // origins of packages.
-func scanSource(store storage.Store, pkgSource packageSource) ([]PackageMetadataItem, error) {
+func scanSource(store storage.Store, pkgSource packageSource) (_ []PackageMetadataItem, err error) {
 	// builder content is content that is present in a builder stage base image
 	builderContentPath, err := os.MkdirTemp("", "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: failed to create temp directory: %w", ErrIO, err)
 	}
 
 	// intermediate content is content that created in a builder stage base during the build
 	intermediateContentPath, err := os.MkdirTemp("", "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: failed to create temp directory: %w", ErrIO, err)
 	}
 
 	// if in debug mode, print the paths to saved content
@@ -217,8 +222,10 @@ func scanSource(store storage.Store, pkgSource packageSource) ([]PackageMetadata
 		log.Printf("[DEBUG] Builder %s content path: %s", pkgSource.pullspec, builderContentPath)
 		log.Printf("[DEBUG] Intermediate %s content path: %s", pkgSource.pullspec, intermediateContentPath)
 	} else {
-		defer os.RemoveAll(builderContentPath)
-		defer os.RemoveAll(intermediateContentPath)
+		defer func() {
+			err = os.RemoveAll(builderContentPath)
+			err = os.RemoveAll(intermediateContentPath)
+		}()
 	}
 
 	err = getContent(store, pkgSource, builderContentPath, intermediateContentPath)
@@ -228,12 +235,12 @@ func scanSource(store storage.Store, pkgSource packageSource) ([]PackageMetadata
 
 	intermediatePkgs, err := sbom.SyftScan(intermediateContentPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to scan intermediate content: %w", err)
 	}
 
 	builderPkgs, err := sbom.SyftScan(builderContentPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to scan builder content: %w", err)
 	}
 
 	return getPackageMetadata(pkgSource, builderPkgs, intermediatePkgs), nil
@@ -246,7 +253,7 @@ func getPackageMetadata(
 	builderPkgs []sbom.SyftPackage,
 	intermediatePkgs []sbom.SyftPackage,
 ) []PackageMetadataItem {
-	var res []PackageMetadataItem
+	res := make([]PackageMetadataItem, 0)
 
 	for _, bpkg := range builderPkgs {
 		res = append(res, PackageMetadataItem{

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -3,8 +3,10 @@
 package capo
 
 import (
-	"github.com/konflux-ci/capo/pkg/containerfile"
+	"slices"
 	"testing"
+
+	"github.com/konflux-ci/capo/pkg/containerfile"
 )
 
 // comparePackageSources compares two slices of packageSource, ignoring order
@@ -42,14 +44,7 @@ func packageSourceEqual(a, b packageSource) bool {
 	}
 
 	for _, aSource := range a.sources {
-		found := false
-		for _, bSource := range b.sources {
-			if aSource == bSource {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(b.sources, aSource) {
 			return false
 		}
 	}


### PR DESCRIPTION
Added linting support using the `golangci-lint` tool.

Fixed warnings that came up during the first lint, mainly using static errors instead of dynamic ones.

Added Apache license, same as Mobster.

Automated releases of Capo via `mage release` and the `goreleaser` tool. The release runs in Github CI on tag push.

https://issues.redhat.com/browse/ISV-6369