### PR TITLE
feat: add support for COPYies containing file patterns with wildcards

### DIFF
--- a/pkg/content.go
+++ b/pkg/content.go
@@ -104,18 +104,17 @@ func getImageContent(
 		full := path.Join(mountPath, src)
 		matches, err := filepath.Glob(full)
 		if err != nil {
-			continue
+			return included, err
 		}
 
 		if len(matches) == 0 {
 			continue
 		}
 
-		foundMatch := false
 		for _, match := range matches {
 			fInfo, err := os.Stat(match)
 			if err != nil {
-				continue
+				return included, err
 			}
 
 			relPath, err := filepath.Rel(mountPath, match)
@@ -136,11 +135,7 @@ func getImageContent(
 				}
 			}
 
-			foundMatch = true
-		}
-
-		if foundMatch {
-			included = append(included, src)
+			included = append(included, "/"+relPath)
 		}
 	}
 

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -104,7 +104,7 @@ func getImageContent(
 		full := path.Join(mountPath, src)
 		matches, err := filepath.Glob(full)
 		if err != nil {
-			return included, err
+			return included, fmt.Errorf("%w: failed to glob pattern %q: %w", ErrIO, src, err)
 		}
 
 		if len(matches) == 0 {
@@ -114,12 +114,12 @@ func getImageContent(
 		for _, match := range matches {
 			fInfo, err := os.Stat(match)
 			if err != nil {
-				return included, err
+				return included, fmt.Errorf("%w: failed to stat %q: %w", ErrIO, match, err)
 			}
 
 			relPath, err := filepath.Rel(mountPath, match)
 			if err != nil {
-				return included, err
+				return included, fmt.Errorf("%w: failed to get relative path for %q: %w", ErrIO, match, err)
 			}
 			dest := path.Join(contentPath, relPath)
 
@@ -127,7 +127,7 @@ func getImageContent(
 				// CopyFS also copies and follows symlinks even if they're outside the specified source,
 				// This is not a problem for us because Syft ignores symbolic links.
 				if err := os.CopyFS(dest, os.DirFS(match)); err != nil {
-					return included, err
+					return included, fmt.Errorf("%w: failed to copy directory %q to %q: %w", ErrIO, match, dest, err)
 				}
 			} else if fInfo.Mode().IsRegular() {
 				if err := copyFile(match, dest); err != nil {

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -179,6 +179,7 @@ func traceSource(
 	aliasToStage map[string]*containerfile.Stage,
 ) {
 	isDirectory := strings.HasSuffix(source, "/")
+	isWildcard := strings.ContainsAny(source, "*?[]")
 
 	foundAncestor := false
 	for _, cp := range currStage.Copies {
@@ -193,12 +194,10 @@ func traceSource(
 		}
 	}
 
-	// If the source is a directory, we want to add it to the accumulator
-	// even if we traced some of the sources. This is because the directory could
+	// If the source is a directory or wildcard pattern, we want to add it to the accumulator
+	// even if we traced some of the sources. This is because the directory/pattern could
 	// contain mixed content - some from this stage, some copied from previous stages.
-	// This occurs when a builder stage copies content from a previous stage into
-	// an already existing directory with some content.
-	if isDirectory || !foundAncestor {
+	if isDirectory || isWildcard || !foundAncestor {
 		acc[currStage] = append(acc[currStage], source)
 	}
 }

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/konflux-ci/capo/internal/sbom"
@@ -181,7 +182,10 @@ func traceSource(
 
 	foundAncestor := false
 	for _, cp := range currStage.Copies {
-		if strings.HasPrefix(cp.Destination, source) {
+		matched, _ := filepath.Match(source, cp.Destination)
+		isDirectoryCopy := strings.HasPrefix(cp.Destination, source)
+		isSourceUnderDestination := strings.HasPrefix(source, cp.Destination)
+		if matched || isDirectoryCopy || isSourceUnderDestination {
 			foundAncestor = true
 			for _, s := range cp.Sources {
 				traceSource(s, aliasToStage[cp.From], acc, aliasToStage)

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -418,7 +418,7 @@ func TestGetPackageSources(t *testing.T) {
 				{
 					alias:    "builder2",
 					pullspec: "docker.io/alpine/helm:latest",
-					sources:  []string{},
+					sources:  []string{"/libs/*.so"},
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds support for wildcard patterns in Containerfile COPY commands. Previously, capo only handled exact file paths and directories.

Modified 'scan.go', function 'traceSource()' and content.go functions 'includes()' and 'getImageContent()' to support working with wildcards.

Added 3 test cases featuring wildcards into 'scan_test.go'.
