### PR TITLE
feat(ISV-6784): pregenerate SBOM information

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,9 +24,9 @@ builds:
       post:
         - upx -9 "{{ .Path }}"
 
-  - id: sbomprobe
-    binary: sbomprobe
-    dir: ./cmd/sbomprobe
+  - id: buildprobe
+    binary: buildprobe
+    dir: ./cmd/buildprobe
     ldflags:
       - -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,25 @@ builds:
       post:
         - upx -9 "{{ .Path }}"
 
+  - id: sbomprobe
+    binary: sbomprobe
+    dir: ./cmd/sbomprobe
+    ldflags:
+      - -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - ppc64le
+    tags:
+      - exclude_graphdriver_btrfs
+    hooks:
+      post:
+        - upx -9 "{{ .Path }}"
+
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     wrap_in_directory: true

--- a/cmd/buildprobe/main.go
+++ b/cmd/buildprobe/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
-	"strings"
 
+	"github.com/konflux-ci/capo/pkg/buildargs"
 	"github.com/konflux-ci/capo/pkg/probe"
 	"github.com/konflux-ci/capo/pkg/repository"
 	"go.yaml.in/yaml/v3"
@@ -60,16 +60,16 @@ func parseArgs() (args, error) {
 		"Path to the Containerfile used in the build. Required.",
 	)
 
-	buildArgs := make(map[string]string)
+	cliArgs := make(map[string]string)
 	flag.Func(
 		"build-arg",
 		"Build argument passed to buildah in the form KEY=VALUE. Can be used multiple times.",
 		func(s string) error {
-			parts := strings.Split(s, "=")
-			if len(parts) != 2 || parts[0] == "" {
+			key, value, err := buildargs.ParseBuildArgLine(s)
+			if err != nil {
 				return ErrBuildArg
 			}
-			buildArgs[parts[0]] = parts[1]
+			cliArgs[key] = value
 			return nil
 		},
 	)
@@ -80,9 +80,24 @@ func parseArgs() (args, error) {
 		"Build target passed to buildah, if any.",
 	)
 
-	// FIXME: build arg file argument support
+	buildArgFile := flag.String(
+		"build-arg-file",
+		"",
+		"Path to a file of build arguments (one KEY=VALUE per line). Read before --build-arg values.",
+	)
 
 	flag.Parse()
+
+	var buildArgs map[string]string
+	if *buildArgFile != "" {
+		fileArgs, err := buildargs.ParseBuildArgFile(*buildArgFile)
+		if err != nil {
+			return args{}, fmt.Errorf("parsing build-arg-file: %w", err)
+		}
+		buildArgs = buildargs.MergeBuildArgs(fileArgs, cliArgs)
+	} else {
+		buildArgs = cliArgs
+	}
 
 	if *cfPath == "" {
 		flag.Usage()

--- a/cmd/buildprobe/main.go
+++ b/cmd/buildprobe/main.go
@@ -51,7 +51,7 @@ func parseArgs() (args, error) {
 	tag := flag.String(
 		"tag",
 		"",
-		"Tag of the built image.",
+		"Tag of the built image. Required.",
 	)
 
 	cfPath := flag.String(

--- a/cmd/buildprobe/main.go
+++ b/cmd/buildprobe/main.go
@@ -31,7 +31,7 @@ func logRevision() {
 }
 
 type args struct {
-	// TODO: description
+	// Tag of the built image
 	tag string
 	// Path to the containerfile to parse
 	containerfilePath string

--- a/cmd/buildprobe/main.go
+++ b/cmd/buildprobe/main.go
@@ -9,8 +9,8 @@ import (
 	"runtime/debug"
 
 	"github.com/konflux-ci/capo/pkg/buildargs"
+	"github.com/konflux-ci/capo/pkg/imagestore"
 	"github.com/konflux-ci/capo/pkg/probe"
-	"github.com/konflux-ci/capo/pkg/repository"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -135,9 +135,9 @@ func main() {
 		}
 	}()
 
-	repo, err := repository.NewBuildahRepository()
+	repo, err := imagestore.NewBuildahStore()
 	if err != nil {
-		log.Fatalf("Could not create buildah repository: %s", err)
+		log.Fatalf("Could not create buildah image store: %s", err)
 	}
 
 	meta, err := probe.Probe(probe.ProbeOpts{

--- a/cmd/buildprobe/main.go
+++ b/cmd/buildprobe/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"runtime/debug"
+	"strings"
+
+	"github.com/konflux-ci/capo/pkg/probe"
+	"github.com/konflux-ci/capo/pkg/repository"
+	"go.yaml.in/yaml/v3"
+)
+
+func logRevision() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				log.Printf("buildprobe was built from revision %q", s.Value)
+				return
+			}
+		}
+		// vcs.revision is only available after build, "go run" isn't enough
+		log.Println("Could not find key vcs.revision in build information")
+	} else {
+		log.Println("Could not read buildprobe build information")
+	}
+
+}
+
+type args struct {
+	// TODO: description
+	tag string
+	// Path to the containerfile to parse
+	containerfilePath string
+	// Build arguments passed to buildah for the build
+	buildArgs map[string]string
+	// Target stage of the buildah build
+	target string
+}
+
+var ErrBuildArg = errors.New("invalid build args syntax")
+var ErrNoContainerfile = errors.New("containerfile argument is required")
+var ErrNoTag = errors.New("tag argument is required")
+var ErrYAMLEncode = errors.New("error while encoding build metadata")
+
+// Define and parse command line arguments and return an "args" struct or an error.
+func parseArgs() (args, error) {
+	tag := flag.String(
+		"tag",
+		"",
+		"Tag of the built image.",
+	)
+
+	cfPath := flag.String(
+		"containerfile",
+		"",
+		"Path to the Containerfile used in the build. Required.",
+	)
+
+	buildArgs := make(map[string]string)
+	flag.Func(
+		"build-arg",
+		"Build argument passed to buildah in the form KEY=VALUE. Can be used multiple times.",
+		func(s string) error {
+			parts := strings.Split(s, "=")
+			if len(parts) != 2 || parts[0] == "" {
+				return ErrBuildArg
+			}
+			buildArgs[parts[0]] = parts[1]
+			return nil
+		},
+	)
+
+	target := flag.String(
+		"target",
+		"",
+		"Build target passed to buildah, if any.",
+	)
+
+	// FIXME: build arg file argument support
+
+	flag.Parse()
+
+	if *cfPath == "" {
+		flag.Usage()
+		return args{}, ErrNoContainerfile
+	}
+
+	if *tag == "" {
+		flag.Usage()
+		return args{}, ErrNoTag
+	}
+
+	return args{
+		tag:               *tag,
+		containerfilePath: *cfPath,
+		target:            *target,
+		buildArgs:         buildArgs,
+	}, nil
+}
+
+func main() {
+	logRevision()
+
+	args, err := parseArgs()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	cfReader, err := os.Open(args.containerfilePath)
+	if err != nil {
+		log.Fatalf("Could not open %s: %+v", args.containerfilePath, err)
+	}
+	defer func() {
+		if cfReader.Close() != nil {
+			log.Fatalf("Could not close %s", args.containerfilePath)
+		}
+	}()
+
+	repo, err := repository.NewBuildahRepository()
+	if err != nil {
+		log.Fatalf("Could not create buildah repository: %s", err)
+	}
+
+	meta, err := probe.Probe(probe.ProbeOpts{
+		Containerfile: cfReader,
+		Target:        args.target,
+		Tag:           args.tag,
+		Args:          args.buildArgs,
+	}, repo)
+	if err != nil {
+		log.Fatalf("Failed to probe build metadata %+v", err)
+	}
+
+	if err := printBuildMetadata(meta); err != nil {
+		log.Fatalf("Failed to encode build metadata: %+v", err)
+	}
+}
+
+// Serialize and print package metadata to stdout.
+func printBuildMetadata(meta probe.BuildMetadata) error {
+	d, err := yaml.Marshal(&meta)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrYAMLEncode, err)
+	}
+
+	fmt.Println(string(d))
+	return nil
+}

--- a/cmd/capo/main.go
+++ b/cmd/capo/main.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
-	"strings"
 
 	"github.com/konflux-ci/capo/pkg"
+	"github.com/konflux-ci/capo/pkg/buildargs"
 	"github.com/konflux-ci/capo/pkg/containerfile"
 )
 
@@ -41,13 +41,19 @@ func parseArgs() (args, error) {
 		"build-arg",
 		"Build argument passed to buildah in the form KEY=VALUE. Can be used multiple times.",
 		func(s string) error {
-			parts := strings.Split(s, "=")
-			if len(parts) != 2 || parts[0] == "" {
+			key, value, err := buildargs.ParseBuildArgLine(s)
+			if err != nil {
 				return ErrBuildArg
 			}
-			buildArgs[parts[0]] = parts[1]
+			buildArgs[key] = value
 			return nil
 		},
+	)
+
+	buildArgFile := flag.String(
+		"build-arg-file",
+		"",
+		"Path to a file of build arguments (one KEY=VALUE per line). Read before --build-arg values.",
 	)
 
 	target := flag.String(
@@ -57,6 +63,14 @@ func parseArgs() (args, error) {
 	)
 
 	flag.Parse()
+
+	if *buildArgFile != "" {
+		fileArgs, err := buildargs.ParseBuildArgFile(*buildArgFile)
+		if err != nil {
+			return args{}, fmt.Errorf("parsing build-arg-file: %w", err)
+		}
+		buildArgs = buildargs.MergeBuildArgs(fileArgs, buildArgs)
+	}
 
 	if *cfPath == "" {
 		flag.Usage()

--- a/docs/buildprobe.md
+++ b/docs/buildprobe.md
@@ -1,7 +1,7 @@
 # Usage
 
-buildprobe extracts build metadata from a Containerfile without performing an
-actual build. It parses the Containerfile, resolves image digests via the local
+buildprobe extracts build metadata from a Containerfile and its associated
+build. It parses the Containerfile, resolves image digests via the local
 buildah store, and prints the result as YAML to stdout.
 
 Because buildprobe accesses the buildah image store, it must run under

--- a/docs/buildprobe.md
+++ b/docs/buildprobe.md
@@ -1,0 +1,78 @@
+# Usage
+
+buildprobe extracts build metadata from a Containerfile without performing an
+actual build. It parses the Containerfile, resolves image digests via the local
+buildah store, and prints the result as YAML to stdout.
+
+Because buildprobe accesses the buildah image store, it must run under
+`buildah unshare` (rootless) or as root.
+
+## Synopsis
+
+```
+buildah unshare buildprobe [flags]
+```
+
+## Flags
+
+- `-containerfile` _path_ — Path to the Containerfile used in the build. **Required.**
+- `-tag` _pullspec_ — Tag of the built image. **Required.**
+- `-build-arg` _KEY=VALUE_ — Build argument passed to buildah. Can be specified multiple times.
+- `-build-arg-file` _path_ — Path to a file of build arguments, one `KEY=VALUE` per line. Blank lines and lines starting with `#` are ignored. Read before `-build-arg` values.
+- `-target` _stage_ — Build target stage passed to buildah, if any. When set, only stages reachable from the target are included in the output.
+
+When the same build argument key appears in both `-build-arg-file` and
+`-build-arg`, the `-build-arg` value takes precedence.
+
+## Output
+
+buildprobe writes YAML to stdout with the following structure:
+
+```yaml
+image:
+    pullspec: <tag>
+    digest: <resolved_digest>
+base_images:
+    - pullspec: <image_reference>
+      digest: <resolved_digest>
+extra_images:
+    - pullspec: <image_reference>
+      digest: <resolved_digest>
+```
+
+- **image** — The built image identified by `-tag`, with its resolved digest.
+- **base_images** — Images from `FROM` instructions that are reachable from the
+  final (or target) stage. Images named `scratch` and `oci-archive:` references
+  are excluded.
+- **extra_images** — Images referenced via `COPY --from=<image>` or
+  `RUN --mount=type=bind,from=<image>` that are not builder stages defined in
+  the Containerfile.
+
+## Examples
+
+Basic usage:
+
+```bash
+buildah unshare buildprobe \
+    -containerfile=Containerfile \
+    -tag=quay.io/myorg/myimage:latest
+```
+
+With build arguments from a file and CLI overrides:
+
+```bash
+buildah unshare buildprobe \
+    -build-arg-file=build-args.env \
+    -build-arg ALPINE_TAG=3.21 \
+    -containerfile=Containerfile \
+    -tag=quay.io/myorg/myimage:latest
+```
+
+Building a specific target stage:
+
+```bash
+buildah unshare buildprobe \
+    -containerfile=Containerfile \
+    -target=packager \
+    -tag=quay.io/myorg/myimage:latest
+```

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/openshift/imagebuilder v1.2.19
 	go.podman.io/image/v5 v5.38.0
 	go.podman.io/storage v1.61.0
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	modernc.org/sqlite v1.38.2
 )
 
@@ -88,8 +89,6 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.17.0 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
-	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
-	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/deitch/magic v0.0.0-20230404182410-1ff89d7342da // indirect
 	github.com/diskfs/go-diskfs v1.7.0 // indirect
@@ -137,7 +136,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gookit/color v1.5.4 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -744,7 +744,6 @@ github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
@@ -845,10 +844,6 @@ github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRq
 github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
-github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYglewc+UyGf6lc8Mj2UaPTHy/iF2De0/77CA=
-github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
-github.com/containers/ocicrypt v1.2.1 h1:0qIOTT9DoYwcKmxSt8QJt+VzMY18onl9jUXsxpVhSmM=
-github.com/containers/ocicrypt v1.2.1/go.mod h1:aD0AAqfMp0MtwqWgHM1bUwe1anx0VazI108CRrSKINQ=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -883,8 +878,6 @@ github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pM
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
-github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
-github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -1143,8 +1136,6 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gookit/color v1.5.4 h1:FZmqs7XOyGgCAxmWyPslpiok1k05wmY3SJTytgvYFs0=
 github.com/gookit/color v1.5.4/go.mod h1:pZJOeOS8DM43rXbp4AZo1n9zCU2qjpcRko0b6/QJi9w=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
@@ -1364,8 +1355,6 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
-github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
@@ -1434,19 +1423,13 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
-github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
-github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
-github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
-github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
-github.com/prometheus/common v0.63.0 h1:YR/EIY1o3mEFP/kZCD7iDMnLPlGyuU2Gb3HIcXnA98k=
-github.com/prometheus/common v0.63.0/go.mod h1:VVFF/fBIoToEnWRVkYoXEkq3R3paCoxG9PXP74SnV18=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
@@ -1661,6 +1644,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 go4.org v0.0.0-20230225012048-214862532bf5 h1:nifaUDeh+rPaBCMPMQHZmvJf+QdpLFnuQPwx+LxVmtc=
 go4.org v0.0.0-20230225012048-214862532bf5/go.mod h1:F57wTi5Lrj6WLyswp5EYV1ncrEbFGHD4hhz6S1ZYeaU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/magefile.go
+++ b/magefile.go
@@ -10,6 +10,7 @@ import (
 
 var Default = Build
 var CapoPackage = "./cmd/capo"
+var BuildprobePackage = "./cmd/buildprobe"
 
 // Runs the capo module in a buildah namespace using 'buildah unshare'.
 // Passes args to capo. Capo arguments must be passed as a single string:
@@ -23,6 +24,18 @@ func Run(capoArgsStr string) error {
 		CapoPackage,
 	}
 	bArgs = append(bArgs, capoArgs...)
+	return sh.RunV("buildah", bArgs...)
+}
+
+func RunProbe(probeArgsStr string) error {
+	probeArgs := strings.Split(probeArgsStr, " ")
+	bArgs := []string{
+		"unshare",
+		"go",
+		"run",
+		BuildprobePackage,
+	}
+	bArgs = append(bArgs, probeArgs...)
 	return sh.RunV("buildah", bArgs...)
 }
 

--- a/pkg/buildargs/buildargs.go
+++ b/pkg/buildargs/buildargs.go
@@ -1,0 +1,64 @@
+package buildargs
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"strings"
+)
+
+// ErrInvalidBuildArg is returned when a build argument line is not in KEY=VALUE format.
+var ErrInvalidBuildArg = errors.New("invalid build arg")
+
+// ParseBuildArgLine parses a single KEY=VALUE line into its key and value.
+// Values may contain '=' characters.
+func ParseBuildArgLine(s string) (string, string, error) {
+	key, value, ok := strings.Cut(s, "=")
+	if !ok || key == "" {
+		return "", "", fmt.Errorf("%w: expected KEY=VALUE, got %q", ErrInvalidBuildArg, s)
+	}
+	return key, value, nil
+}
+
+// ParseBuildArgFile reads a file of build arguments, one KEY=VALUE per line.
+// Blank lines and lines starting with '#' are ignored.
+// When the same key appears multiple times, the last value wins.
+func ParseBuildArgFile(path string) (result map[string]string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening build-arg-file: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing build-arg-file: %w", cerr)
+		}
+	}()
+
+	args := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, err := ParseBuildArgLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("in %s: %w", path, err)
+		}
+		args[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return args, nil
+}
+
+// MergeBuildArgs merges file args with CLI args. CLI args take precedence.
+func MergeBuildArgs(fileArgs, cliArgs map[string]string) map[string]string {
+	merged := make(map[string]string, len(fileArgs)+len(cliArgs))
+	maps.Copy(merged, fileArgs)
+	maps.Copy(merged, cliArgs)
+	return merged
+}

--- a/pkg/buildargs/buildargs_test.go
+++ b/pkg/buildargs/buildargs_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseBuildArgLine(t *testing.T) {
@@ -71,13 +73,8 @@ EQUALS=a=b=c
 		"EQUALS": "a=b=c",
 	}
 
-	if len(args) != len(expected) {
-		t.Fatalf("got %d args, want %d", len(args), len(expected))
-	}
-	for k, want := range expected {
-		if got := args[k]; got != want {
-			t.Errorf("args[%q] = %q, want %q", k, got, want)
-		}
+	if diff := cmp.Diff(expected, args); diff != "" {
+		t.Errorf("ParseBuildArgFile() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -122,12 +119,7 @@ func TestMergeBuildArgs(t *testing.T) {
 		"C": "from-cli",
 	}
 
-	if len(merged) != len(expected) {
-		t.Fatalf("got %d args, want %d", len(merged), len(expected))
-	}
-	for k, want := range expected {
-		if got := merged[k]; got != want {
-			t.Errorf("merged[%q] = %q, want %q", k, got, want)
-		}
+	if diff := cmp.Diff(expected, merged); diff != "" {
+		t.Errorf("MergeBuildArgs() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/buildargs/buildargs_test.go
+++ b/pkg/buildargs/buildargs_test.go
@@ -1,0 +1,133 @@
+package buildargs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseBuildArgLine(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		wantKey string
+		wantVal string
+		wantErr bool
+	}{
+		{name: "simple", input: "FOO=bar", wantKey: "FOO", wantVal: "bar"},
+		{name: "value with equals", input: "FOO=bar=baz", wantKey: "FOO", wantVal: "bar=baz"},
+		{name: "empty value", input: "FOO=", wantKey: "FOO", wantVal: ""},
+		{name: "no equals", input: "FOOBAR", wantErr: true},
+		{name: "empty key", input: "=value", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			key, val, err := ParseBuildArgLine(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got key=%q val=%q", key, val)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if key != tt.wantKey || val != tt.wantVal {
+				t.Errorf("got key=%q val=%q, want key=%q val=%q", key, val, tt.wantKey, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestParseBuildArgFile(t *testing.T) {
+	t.Parallel()
+	content := `# This is a comment
+FOO=bar
+
+BAZ=qux
+# Another comment
+DUP=first
+DUP=second
+EQUALS=a=b=c
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "args.conf")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	args, err := ParseBuildArgFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"FOO":    "bar",
+		"BAZ":    "qux",
+		"DUP":    "second",
+		"EQUALS": "a=b=c",
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("got %d args, want %d", len(args), len(expected))
+	}
+	for k, want := range expected {
+		if got := args[k]; got != want {
+			t.Errorf("args[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestParseBuildArgFileNotFound(t *testing.T) {
+	t.Parallel()
+	_, err := ParseBuildArgFile("/nonexistent/path")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestParseBuildArgFileInvalidLine(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.conf")
+	if err := os.WriteFile(path, []byte("NOEQUALS\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseBuildArgFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid line")
+	}
+}
+
+func TestMergeBuildArgs(t *testing.T) {
+	t.Parallel()
+	fileArgs := map[string]string{
+		"A": "from-file",
+		"B": "from-file",
+	}
+	cliArgs := map[string]string{
+		"B": "from-cli",
+		"C": "from-cli",
+	}
+
+	merged := MergeBuildArgs(fileArgs, cliArgs)
+
+	expected := map[string]string{
+		"A": "from-file",
+		"B": "from-cli",
+		"C": "from-cli",
+	}
+
+	if len(merged) != len(expected) {
+		t.Fatalf("got %d args, want %d", len(merged), len(expected))
+	}
+	for k, want := range expected {
+		if got := merged[k]; got != want {
+			t.Errorf("merged[%q] = %q, want %q", k, got, want)
+		}
+	}
+}

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/openshift/imagebuilder"
@@ -37,6 +38,23 @@ type Copy struct {
 	Type CopyType
 }
 
+// A mount reference from a RUN --mount instruction in a Containerfile stage.
+type Mount struct {
+	// Alias of the stage the mount references when Mount.Type==MountTypeBuilder
+	// or a pullspec when Mount.Type==MountTypeExternal
+	From string
+	// Type of the mount. Specifies whether it references a builder stage
+	// or an external image directly.
+	Type MountType
+}
+
+type MountType int
+
+const (
+	MountTypeBuilder MountType = iota
+	MountTypeExternal
+)
+
 // A builder or final stage in a Containerfile
 type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final
@@ -45,6 +63,8 @@ type Stage struct {
 	Base string
 	// Builder copies in this stage
 	Copies []Copy
+	// Mount references in this stage
+	Mounts []Mount
 }
 
 type BuildOptions struct {
@@ -98,7 +118,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 			s.Name = FinalStage
 		}
 
-		copies, err := getBuilderCopiesInStage(s, stageNames)
+		copies, mounts, err := parseStageRefs(s, stageNames)
 		if err != nil {
 			return res, err
 		}
@@ -107,6 +127,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 			Alias:  s.Name,
 			Base:   pullspecs[i],
 			Copies: copies,
+			Mounts: mounts,
 		})
 	}
 
@@ -140,24 +161,26 @@ func resolvePullspecs(stages []imagebuilder.Stage) []string {
 	return res
 }
 
-// getBuilderCopiesInStage parses the AST for the passed imagebuilder.Stage and
-// returns a slice of Copy structs, specifying which builder-type copies are
-// present in that stage.
+// parseStageRefs parses the AST for the passed imagebuilder.Stage and
+// returns slices of Copy and Mount structs found in the stage.
+//
 // A COPY command is builder-type if the "--from" flag is specified and it copies from
 // a builder stage or directly from an image.
-// Uses the passed previous stageNames to specify whether copies are from a stage
-// or directly from an image.
+// A Mount is extracted from RUN --mount instructions that specify a "from" option.
+// Uses the passed previous stageNames to specify whether references are to a stage
+// or directly to an image.
 //
 // WORKDIR commands are taken into account and the destinations of COPY commands
 // are resolved to be absolute instead of relative, where needed. If the Containerfile
 // contains builder-type COPY commands that copy to a relative destination and don't
-// specify the WORKDIR in advance, getBuilderCopiesInStage returns a workdirError.
+// specify the WORKDIR in advance, parseStageRefs returns a workdirError.
 // This limitation exists because each base image can set its own WORKDIR and this cannot
 // be determined based on just the Containerfile.
 //
 // WARNING: named contexts in the Containerfile are not supported
-func getBuilderCopiesInStage(s imagebuilder.Stage, stageNames []string) ([]Copy, error) {
+func parseStageRefs(s imagebuilder.Stage, stageNames []string) ([]Copy, []Mount, error) {
 	copies := make([]Copy, 0)
+	mounts := make([]Mount, 0)
 	workdir := ""
 	headingEnv := argsMapToSlice(s.Builder.HeadingArgs)
 	userEnv := argsMapToSlice(s.Builder.Args)
@@ -176,7 +199,7 @@ func getBuilderCopiesInStage(s imagebuilder.Stage, stageNames []string) ([]Copy,
 				// if the path is relative, it is relative to the last set workdir
 				// so we need to fail if a WORKDIR command was not yet specified
 				if workdir == "" {
-					return copies, fmt.Errorf("%w: %q", ErrAmbiguousRelativePath, child.Original)
+					return copies, mounts, fmt.Errorf("%w: %q", ErrAmbiguousRelativePath, child.Original)
 				}
 
 				workdir = filepath.Join(workdir, dirPath)
@@ -185,16 +208,67 @@ func getBuilderCopiesInStage(s imagebuilder.Stage, stageNames []string) ([]Copy,
 		case "copy":
 			cp, err := parseCopy(child, workdir, env, stageNames)
 			if err != nil {
-				return copies, err
+				return copies, mounts, err
 			}
 
 			if cp != nil {
 				copies = append(copies, *cp)
 			}
+
+		case "run":
+			mounts = append(mounts, parseMounts(child, env, stageNames)...)
 		}
 	}
 
-	return copies, nil
+	return copies, mounts, nil
+}
+
+// isStageRef returns true if ref matches a known stage, either by name or by
+// numeric index.
+func isStageRef(ref string, stageNames []string) bool {
+	if slices.Contains(stageNames, ref) {
+		return true
+	}
+	if i, err := strconv.Atoi(ref); err == nil && 0 <= i && i < len(stageNames) {
+		return true
+	}
+	return false
+}
+
+// parseMounts extracts Mount references from a RUN instruction's --mount flags.
+// Only mounts with a "from" option are returned. Uses the passed previous stage
+// names to classify whether the mount references a builder stage or an external image.
+func parseMounts(node *parser.Node, env []string, stageNames []string) []Mount {
+	var mounts []Mount
+	for _, fl := range node.Flags {
+		if !strings.HasPrefix(fl, "--mount=") {
+			continue
+		}
+
+		mountOpts := strings.TrimPrefix(fl, "--mount=")
+		from := ""
+		for opt := range strings.SplitSeq(mountOpts, ",") {
+			if val, ok := strings.CutPrefix(opt, "from="); ok {
+				from, _ = imagebuilder.ProcessWord(val, env)
+				break
+			}
+		}
+
+		if from == "" {
+			continue
+		}
+
+		mountType := MountTypeBuilder
+		if !isStageRef(from, stageNames) {
+			mountType = MountTypeExternal
+		}
+
+		mounts = append(mounts, Mount{
+			From: from,
+			Type: mountType,
+		})
+	}
+	return mounts
 }
 
 // parseCopy takes a raw dockerfile parser Node and optionally returns a pointer
@@ -249,7 +323,7 @@ func parseCopy(node *parser.Node, workdir string, env []string, stageNames []str
 		}
 
 		cpType := CopyTypeBuilder
-		if !slices.Contains(stageNames, from) {
+		if !isStageRef(from, stageNames) {
 			cpType = CopyTypeExternal
 		}
 

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -41,9 +41,8 @@ type Copy struct {
 type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final
 	Alias string
-	// Base image for the stage
-	// FIXME: maybe call this "base" or something, since it can also be Scratch or oci:archive
-	Pullspec string
+	// Base image for the stage. Can be a pullspec, "scratch", or "oci:archive".
+	Base string
 	// Builder copies in this stage
 	Copies []Copy
 }
@@ -105,9 +104,9 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 		}
 
 		res = append(res, Stage{
-			Alias:    s.Name,
-			Pullspec: aliasToPullspec[s.Name],
-			Copies:   copies,
+			Alias:  s.Name,
+			Base:   aliasToPullspec[s.Name],
+			Copies: copies,
 		})
 	}
 

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -89,7 +89,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 		rawStages = stagesTargeted
 	}
 
-	aliasToPullspec := mapAliasesToPullspecs(rawStages)
+	pullspecs := resolvePullspecs(rawStages)
 	stageNames := make([]string, 0)
 
 	for i, s := range rawStages {
@@ -105,7 +105,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 
 		res = append(res, Stage{
 			Alias:  s.Name,
-			Base:   aliasToPullspec[s.Name],
+			Base:   pullspecs[i],
 			Copies: copies,
 		})
 	}
@@ -123,23 +123,18 @@ func argsMapToSlice(m map[string]string) []string {
 	return s
 }
 
-// mapAliasesToPullspecs uses the passed imagebuilder.Stage structs to create
-// a mapping between stage aliases and the base image pullspecs for those stages.
-func mapAliasesToPullspecs(stages []imagebuilder.Stage) map[string]string {
-	res := make(map[string]string)
+// resolvePullspecs returns the base image pullspec for each stage, in order.
+func resolvePullspecs(stages []imagebuilder.Stage) []string {
+	res := make([]string, 0, len(stages))
 
-	for i, s := range stages {
-		alias := s.Name
-		if i == len(stages)-1 {
-			alias = FinalStage
-		}
-
+	for _, s := range stages {
 		headingEnv := argsMapToSlice(s.Builder.HeadingArgs)
 		userEnv := argsMapToSlice(s.Builder.Args)
 		env := append(headingEnv, userEnv...)
 
 		fromNode := s.Node.Children[0]
-		res[alias], _ = imagebuilder.ProcessWord(fromNode.Next.Value, env)
+		pullspec, _ := imagebuilder.ProcessWord(fromNode.Next.Value, env)
+		res = append(res, pullspec)
 	}
 
 	return res

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -1,3 +1,5 @@
+// Package containerfile parses Containerfiles (Dockerfiles) into a structured
+// representation of build stages, COPY commands, and RUN --mount references.
 package containerfile
 
 import (
@@ -13,12 +15,17 @@ import (
 	"github.com/openshift/imagebuilder/dockerfile/parser"
 )
 
+// FinalStage is the sentinel alias assigned to the last stage in a parsed
+// Containerfile, distinguishing it from named builder stages.
 var FinalStage string = ""
 
+// CopyType classifies a COPY command by its source origin.
 type CopyType int
 
 const (
+	// CopyTypeBuilder indicates a COPY from a previous builder stage.
 	CopyTypeBuilder CopyType = iota
+	// CopyTypeExternal indicates a COPY directly from an external image.
 	CopyTypeExternal
 )
 
@@ -48,10 +55,13 @@ type Mount struct {
 	Type MountType
 }
 
+// MountType classifies a RUN --mount reference by its source origin.
 type MountType int
 
 const (
+	// MountTypeBuilder indicates a mount from a previous builder stage.
 	MountTypeBuilder MountType = iota
+	// MountTypeExternal indicates a mount directly from an external image.
 	MountTypeExternal
 )
 
@@ -67,6 +77,7 @@ type Stage struct {
 	Mounts []Mount
 }
 
+// BuildOptions controls how a Containerfile is parsed.
 type BuildOptions struct {
 	// Build arguments passed to buildah for the build
 	Args map[string]string
@@ -74,8 +85,15 @@ type BuildOptions struct {
 	Target string
 }
 
+// ErrTargetNotFound is returned when the target stage specified in
+// BuildOptions does not exist in the Containerfile.
 var ErrTargetNotFound = errors.New("specified target stage was not found in the containerfile")
+
+// ErrAmbiguousRelativePath is returned when a COPY destination or WORKDIR uses
+// a relative path but no prior WORKDIR has been set in that stage.
 var ErrAmbiguousRelativePath = errors.New("relative path in containerfile is ambiguous")
+
+// ErrParse is returned when the Containerfile cannot be parsed.
 var ErrParse = errors.New("error while parsing containerfile")
 
 // Parse reads a Containerfile from the passed reader and uses the passed

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -127,7 +127,10 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 		rawStages = stagesTargeted
 	}
 
-	pullspecs := resolvePullspecs(rawStages)
+	pullspecs, err := resolvePullspecs(rawStages)
+	if err != nil {
+		return nil, err
+	}
 	stageNames := make([]string, 0)
 
 	for i, s := range rawStages {
@@ -163,7 +166,7 @@ func argsMapToSlice(m map[string]string) []string {
 }
 
 // resolvePullspecs returns the base image pullspec for each stage, in order.
-func resolvePullspecs(stages []imagebuilder.Stage) []string {
+func resolvePullspecs(stages []imagebuilder.Stage) ([]string, error) {
 	res := make([]string, 0, len(stages))
 
 	for _, s := range stages {
@@ -172,11 +175,14 @@ func resolvePullspecs(stages []imagebuilder.Stage) []string {
 		env := append(headingEnv, userEnv...)
 
 		fromNode := s.Node.Children[0]
-		pullspec, _ := imagebuilder.ProcessWord(fromNode.Next.Value, env)
+		pullspec, err := imagebuilder.ProcessWord(fromNode.Next.Value, env)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrParse, err)
+		}
 		res = append(res, pullspec)
 	}
 
-	return res
+	return res, nil
 }
 
 // parseStageRefs parses the AST for the passed imagebuilder.Stage and
@@ -234,7 +240,11 @@ func parseStageRefs(s imagebuilder.Stage, stageNames []string) ([]Copy, []Mount,
 			}
 
 		case "run":
-			mounts = append(mounts, parseMounts(child, env, stageNames)...)
+			runMounts, err := parseMounts(child, env, stageNames)
+			if err != nil {
+				return copies, mounts, err
+			}
+			mounts = append(mounts, runMounts...)
 		}
 	}
 
@@ -256,7 +266,7 @@ func isStageRef(ref string, stageNames []string) bool {
 // parseMounts extracts Mount references from a RUN instruction's --mount flags.
 // Only mounts with a "from" option are returned. Uses the passed previous stage
 // names to classify whether the mount references a builder stage or an external image.
-func parseMounts(node *parser.Node, env []string, stageNames []string) []Mount {
+func parseMounts(node *parser.Node, env []string, stageNames []string) ([]Mount, error) {
 	var mounts []Mount
 	for _, fl := range node.Flags {
 		if !strings.HasPrefix(fl, "--mount=") {
@@ -267,7 +277,11 @@ func parseMounts(node *parser.Node, env []string, stageNames []string) []Mount {
 		from := ""
 		for opt := range strings.SplitSeq(mountOpts, ",") {
 			if val, ok := strings.CutPrefix(opt, "from="); ok {
-				from, _ = imagebuilder.ProcessWord(val, env)
+				var err error
+				from, err = imagebuilder.ProcessWord(val, env)
+				if err != nil {
+					return nil, fmt.Errorf("%w: %w", ErrParse, err)
+				}
 				break
 			}
 		}
@@ -286,7 +300,7 @@ func parseMounts(node *parser.Node, env []string, stageNames []string) []Mount {
 			Type: mountType,
 		})
 	}
-	return mounts
+	return mounts, nil
 }
 
 // parseCopy takes a raw dockerfile parser Node and optionally returns a pointer
@@ -306,7 +320,10 @@ func parseCopy(node *parser.Node, workdir string, env []string, stageNames []str
 		if !strings.HasPrefix(fl, "--from=") {
 			continue
 		}
-		from, _ := imagebuilder.ProcessWord(strings.TrimPrefix(fl, "--from="), env)
+		from, err := imagebuilder.ProcessWord(strings.TrimPrefix(fl, "--from="), env)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrParse, err)
+		}
 
 		// aggregate the COPY arguments by iterating the nodes
 		args := make([]string, 0)

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -42,6 +42,7 @@ type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final
 	Alias string
 	// Base image for the stage
+	// FIXME: maybe call this "base" or something, since it can also be Scratch or oci:archive
 	Pullspec string
 	// Builder copies in this stage
 	Copies []Copy
@@ -128,14 +129,18 @@ func argsMapToSlice(m map[string]string) []string {
 func mapAliasesToPullspecs(stages []imagebuilder.Stage) map[string]string {
 	res := make(map[string]string)
 
-	// skip final stage, copies from that stage are not allowed
-	for _, s := range stages[:len(stages)-1] {
+	for i, s := range stages {
+		alias := s.Name
+		if i == len(stages)-1 {
+			alias = FinalStage
+		}
+
 		headingEnv := argsMapToSlice(s.Builder.HeadingArgs)
 		userEnv := argsMapToSlice(s.Builder.Args)
 		env := append(headingEnv, userEnv...)
 
 		fromNode := s.Node.Children[0]
-		res[s.Name], _ = imagebuilder.ProcessWord(fromNode.Next.Value, env)
+		res[alias], _ = imagebuilder.ProcessWord(fromNode.Next.Value, env)
 	}
 
 	return res

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -25,6 +25,7 @@ func TestParseBuiltinArgs(t *testing.T) {
 			Alias:  "builder",
 			Base:   expectedPullspec,
 			Copies: []Copy{},
+			Mounts: []Mount{},
 		},
 		{
 			Alias: FinalStage,
@@ -36,6 +37,7 @@ func TestParseBuiltinArgs(t *testing.T) {
 					Destination: "/usr/bin/binary",
 				},
 			},
+			Mounts: []Mount{},
 		},
 	}
 
@@ -105,6 +107,7 @@ func TestParse(t *testing.T) {
 					Alias:  "builder",
 					Base:   "docker.io/library/alpine:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: FinalStage,
@@ -123,6 +126,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 			},
 		},
@@ -146,6 +150,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeExternal,
 						},
 					},
+					Mounts: []Mount{},
 				},
 			},
 		},
@@ -160,11 +165,13 @@ func TestParse(t *testing.T) {
 					Alias:  "builder1",
 					Base:   "docker.io/library/fedora:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias:  "builder2",
 					Base:   "docker.io/alpine/helm:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: FinalStage,
@@ -183,6 +190,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 			},
 		},
@@ -197,6 +205,7 @@ func TestParse(t *testing.T) {
 					Alias:  "builder1",
 					Base:   "docker.io/library/fedora:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: "builder2",
@@ -209,6 +218,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: FinalStage,
@@ -221,6 +231,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 			},
 		},
@@ -240,6 +251,7 @@ func TestParse(t *testing.T) {
 					Alias:  "builder",
 					Base:   "docker.io/alpine/helm:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: FinalStage,
@@ -288,6 +300,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 			},
 		},
@@ -302,6 +315,7 @@ func TestParse(t *testing.T) {
 					Alias:  "builder1",
 					Base:   "docker.io/library/fedora:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: "builder2",
@@ -314,6 +328,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: FinalStage,
@@ -326,6 +341,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 			},
 		},
@@ -341,6 +357,7 @@ func TestParse(t *testing.T) {
 					Alias:  "builder1",
 					Base:   "docker.io/library/fedora:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: "builder2",
@@ -359,6 +376,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: FinalStage,
@@ -371,6 +389,134 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
+				},
+			},
+		},
+		"COPY --from numeric stage index": {
+			containerfile: `FROM quay.io/rhel:9
+							FROM scratch
+							COPY --from=0 /usr/bin/binary /usr/bin/binary`,
+			expected: []Stage{
+				{
+					Alias:  "0",
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+				},
+				{
+					Alias: FinalStage,
+					Base:  "scratch",
+					Copies: []Copy{
+						{
+							From:        "0",
+							Sources:     []string{"/usr/bin/binary"},
+							Destination: "/usr/bin/binary",
+							Type:        CopyTypeBuilder,
+						},
+					},
+					Mounts: []Mount{},
+				},
+			},
+		},
+		"COPY --from numeric index with named stage": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							FROM scratch
+							COPY --from=0 /usr/bin/binary /usr/bin/binary`,
+			expected: []Stage{
+				{
+					Alias:  "builder",
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+				},
+				{
+					Alias: FinalStage,
+					Base:  "scratch",
+					Copies: []Copy{
+						{
+							From:        "0",
+							Sources:     []string{"/usr/bin/binary"},
+							Destination: "/usr/bin/binary",
+							Type:        CopyTypeBuilder,
+						},
+					},
+					Mounts: []Mount{},
+				},
+			},
+		},
+		"COPY --from numeric index out of bounds is external image": {
+			containerfile: `FROM quay.io/rhel:9
+							COPY --from=5 /usr/bin/binary /usr/bin/binary`,
+			expected: []Stage{
+				{
+					Alias: FinalStage,
+					Base:  "quay.io/rhel:9",
+					Copies: []Copy{
+						{
+							From:        "5",
+							Sources:     []string{"/usr/bin/binary"},
+							Destination: "/usr/bin/binary",
+							Type:        CopyTypeExternal,
+						},
+					},
+					Mounts: []Mount{},
+				},
+			},
+		},
+		"RUN --mount=from external image": {
+			containerfile: `FROM quay.io/rhel:9
+							RUN --mount=type=bind,from=quay.io/tools:1,src=/bin/tool,dst=/tmp/tool /tmp/tool --version`,
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{
+						{From: "quay.io/tools:1", Type: MountTypeExternal},
+					},
+				},
+			},
+		},
+		"RUN --mount=from builder stage": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							FROM scratch
+							RUN --mount=type=bind,from=builder,src=/app,dst=/app ls /app`,
+			expected: []Stage{
+				{
+					Alias:  "builder",
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+				},
+				{
+					Alias:  FinalStage,
+					Base:   "scratch",
+					Copies: []Copy{},
+					Mounts: []Mount{
+						{From: "builder", Type: MountTypeBuilder},
+					},
+				},
+			},
+		},
+		"RUN --mount=from numeric stage index": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							FROM scratch
+							RUN --mount=type=bind,from=0,src=/app,dst=/app ls /app`,
+			expected: []Stage{
+				{
+					Alias:  "builder",
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+				},
+				{
+					Alias:  FinalStage,
+					Base:   "scratch",
+					Copies: []Copy{},
+					Mounts: []Mount{
+						{From: "0", Type: MountTypeBuilder},
+					},
 				},
 			},
 		},
@@ -380,11 +526,11 @@ func TestParse(t *testing.T) {
 							FROM scratch
 							COPY --from=builder /app /app`,
 			expected: []Stage{
-				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}},
-				{Alias: "builder", Base: "quay.io/fedora:42", Copies: []Copy{}},
+				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}, Mounts: []Mount{}},
+				{Alias: "builder", Base: "quay.io/fedora:42", Copies: []Copy{}, Mounts: []Mount{}},
 				{Alias: FinalStage, Base: "scratch", Copies: []Copy{
 					{From: "builder", Sources: []string{"/app"}, Destination: "/app", Type: CopyTypeBuilder},
-				}},
+				}, Mounts: []Mount{}},
 			},
 		},
 		"complex multi-stage with multiple final copies": {
@@ -400,6 +546,7 @@ func TestParse(t *testing.T) {
 					Alias:  "builder1",
 					Base:   "docker.io/library/fedora:latest",
 					Copies: []Copy{},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: "builder2",
@@ -412,6 +559,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 				{
 					Alias: FinalStage,
@@ -436,6 +584,7 @@ func TestParse(t *testing.T) {
 							Type:        CopyTypeBuilder,
 						},
 					},
+					Mounts: []Mount{},
 				},
 			},
 		},

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -22,13 +22,13 @@ func TestParseBuiltinArgs(t *testing.T) {
 
 	expected := []Stage{
 		{
-			Alias:    "builder",
-			Pullspec: expectedPullspec,
-			Copies:   []Copy{},
+			Alias:  "builder",
+			Base:   expectedPullspec,
+			Copies: []Copy{},
 		},
 		{
-			Alias:    FinalStage,
-			Pullspec: "scratch",
+			Alias: FinalStage,
+			Base:  "scratch",
 			Copies: []Copy{
 				{
 					From:        "builder",
@@ -102,13 +102,13 @@ func TestParse(t *testing.T) {
 			},
 			expected: []Stage{
 				{
-					Alias:    "builder",
-					Pullspec: "docker.io/library/alpine:latest",
-					Copies:   []Copy{},
+					Alias:  "builder",
+					Base:   "docker.io/library/alpine:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    FinalStage,
-					Pullspec: "scratch",
+					Alias: FinalStage,
+					Base:  "scratch",
 					Copies: []Copy{
 						{
 							From:        "docker.io/library/fedora:latest",
@@ -136,8 +136,8 @@ func TestParse(t *testing.T) {
 			},
 			expected: []Stage{
 				{
-					Alias:    FinalStage,
-					Pullspec: "docker.io/library/fedora:latest",
+					Alias: FinalStage,
+					Base:  "docker.io/library/fedora:latest",
 					Copies: []Copy{
 						{
 							From:        "docker.io/library/alpine:latest",
@@ -157,18 +157,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/helm /usr/bin/helm`,
 			expected: []Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
-					Copies:   []Copy{},
+					Alias:  "builder2",
+					Base:   "docker.io/alpine/helm:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    FinalStage,
-					Pullspec: "scratch",
+					Alias: FinalStage,
+					Base:  "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -194,13 +194,13 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/oras /usr/bin/oras`,
 			expected: []Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -211,8 +211,8 @@ func TestParse(t *testing.T) {
 					},
 				},
 				{
-					Alias:    FinalStage,
-					Pullspec: "scratch",
+					Alias: FinalStage,
+					Base:  "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -237,13 +237,13 @@ func TestParse(t *testing.T) {
 							COPY --from=builder /usr/bin/oras .`,
 			expected: []Stage{
 				{
-					Alias:    "builder",
-					Pullspec: "docker.io/alpine/helm:latest",
-					Copies:   []Copy{},
+					Alias:  "builder",
+					Base:   "docker.io/alpine/helm:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    FinalStage,
-					Pullspec: "scratch",
+					Alias: FinalStage,
+					Base:  "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder",
@@ -299,13 +299,13 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/oras /usr/bin/helm /app/`,
 			expected: []Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -316,8 +316,8 @@ func TestParse(t *testing.T) {
 					},
 				},
 				{
-					Alias:    FinalStage,
-					Pullspec: "scratch",
+					Alias: FinalStage,
+					Base:  "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -338,13 +338,13 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /app/ /app/`,
 			expected: []Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -361,8 +361,8 @@ func TestParse(t *testing.T) {
 					},
 				},
 				{
-					Alias:    FinalStage,
-					Pullspec: "scratch",
+					Alias: FinalStage,
+					Base:  "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -384,13 +384,13 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/helm /usr/bin/helm`,
 			expected: []Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -401,8 +401,8 @@ func TestParse(t *testing.T) {
 					},
 				},
 				{
-					Alias:    FinalStage,
-					Pullspec: "scratch",
+					Alias: FinalStage,
+					Base:  "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder1",

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -5,10 +5,11 @@ package containerfile
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseBuiltinArgs(t *testing.T) {
@@ -27,7 +28,7 @@ func TestParseBuiltinArgs(t *testing.T) {
 		},
 		{
 			Alias:    FinalStage,
-			Pullspec: "",
+			Pullspec: "scratch",
 			Copies: []Copy{
 				{
 					From:        "builder",
@@ -45,8 +46,8 @@ func TestParseBuiltinArgs(t *testing.T) {
 		t.Fatalf("Parsing failed: %v", err)
 	}
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("Actual parsed stages %+v don't match expected %+v", actual, expected)
+	if diff := cmp.Diff(actual, expected); diff != "" {
+		t.Errorf("Parse() result mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -107,7 +108,7 @@ func TestParse(t *testing.T) {
 				},
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "scratch",
 					Copies: []Copy{
 						{
 							From:        "docker.io/library/fedora:latest",
@@ -136,7 +137,7 @@ func TestParse(t *testing.T) {
 			expected: []Stage{
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "docker.io/library/fedora:latest",
 					Copies: []Copy{
 						{
 							From:        "docker.io/library/alpine:latest",
@@ -167,7 +168,7 @@ func TestParse(t *testing.T) {
 				},
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -211,7 +212,7 @@ func TestParse(t *testing.T) {
 				},
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -242,7 +243,7 @@ func TestParse(t *testing.T) {
 				},
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder",
@@ -316,7 +317,7 @@ func TestParse(t *testing.T) {
 				},
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -361,7 +362,7 @@ func TestParse(t *testing.T) {
 				},
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -401,7 +402,7 @@ func TestParse(t *testing.T) {
 				},
 				{
 					Alias:    FinalStage,
-					Pullspec: "",
+					Pullspec: "scratch",
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -436,8 +437,8 @@ func TestParse(t *testing.T) {
 				t.Fatalf("Parsing failed: %v", err)
 			}
 
-			if !reflect.DeepEqual(actual, test.expected) {
-				t.Fatalf("Actual parsed stages %+v don't match expected %+v", actual, test.expected)
+			if diff := cmp.Diff(actual, test.expected); diff != "" {
+				t.Errorf("Parse() result mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -46,7 +46,7 @@ func TestParseBuiltinArgs(t *testing.T) {
 		t.Fatalf("Parsing failed: %v", err)
 	}
 
-	if diff := cmp.Diff(actual, expected); diff != "" {
+	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Errorf("Parse() result mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -374,6 +374,19 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		"duplicate stage names": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							FROM quay.io/fedora:42 AS builder
+							FROM scratch
+							COPY --from=builder /app /app`,
+			expected: []Stage{
+				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}},
+				{Alias: "builder", Base: "quay.io/fedora:42", Copies: []Copy{}},
+				{Alias: FinalStage, Base: "scratch", Copies: []Copy{
+					{From: "builder", Sources: []string{"/app"}, Destination: "/app", Type: CopyTypeBuilder},
+				}},
+			},
+		},
 		"complex multi-stage with multiple final copies": {
 			containerfile: `FROM docker.io/library/fedora:latest AS builder1
 							FROM docker.io/alpine/helm:latest AS builder2
@@ -437,7 +450,7 @@ func TestParse(t *testing.T) {
 				t.Fatalf("Parsing failed: %v", err)
 			}
 
-			if diff := cmp.Diff(actual, test.expected); diff != "" {
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
 				t.Errorf("Parse() result mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -1,6 +1,6 @@
-// Package repository provides access to container image storage for resolving
+// Package imagestore provides access to container image storage for resolving
 // image pullspecs to their digests.
-package repository
+package imagestore
 
 import (
 	"errors"
@@ -10,14 +10,14 @@ import (
 	"go.podman.io/storage/pkg/reexec"
 )
 
-// Repository abstracts container image storage operations, primarily the
+// ImageStore abstracts container image storage operations, primarily the
 // resolution of image pullspecs to their content digests.
-type Repository interface {
+type ImageStore interface {
 	ResolveDigest(string) (string, error)
 }
 
-// BuildahRepository is a Repository backed by a local buildah/containers storage.
-type BuildahRepository struct {
+// BuildahStore is an ImageStore backed by a local buildah/containers storage.
+type BuildahStore struct {
 	store storage.Store
 }
 
@@ -29,33 +29,33 @@ var ErrPullspecResolve = errors.New("failed to resolve pullspec")
 // initialized.
 var ErrBuildahStorageSetup = errors.New("error while setting up buildah storage")
 
-// NewBuildahRepository creates a BuildahRepository using the default
+// NewBuildahStore creates a BuildahStore using the default
 // containers/storage location.
-func NewBuildahRepository() (Repository, error) {
+func NewBuildahStore() (ImageStore, error) {
 	// The containers/storage library requires this to run for some operations
 	if reexec.Init() {
-		return &BuildahRepository{}, fmt.Errorf("%w: failed to init reexec", ErrBuildahStorageSetup)
+		return &BuildahStore{}, fmt.Errorf("%w: failed to init reexec", ErrBuildahStorageSetup)
 	}
 
 	opts, err := storage.DefaultStoreOptions()
 	if err != nil {
-		return &BuildahRepository{},
+		return &BuildahStore{},
 			fmt.Errorf("%w: failed to create default storage options: %w", ErrBuildahStorageSetup, err)
 	}
 
 	store, err := storage.GetStore(opts)
 	if err != nil {
-		return &BuildahRepository{}, fmt.Errorf("%w: failed to create storage: %w", ErrBuildahStorageSetup, err)
+		return &BuildahStore{}, fmt.Errorf("%w: failed to create storage: %w", ErrBuildahStorageSetup, err)
 	}
 
-	return &BuildahRepository{
+	return &BuildahStore{
 		store: store,
 	}, nil
 }
 
 // ResolveDigest looks up the given pullspec in the local storage and returns
 // its content digest in the form "sha256:<hex>".
-func (repo *BuildahRepository) ResolveDigest(pullspec string) (string, error) {
+func (repo *BuildahStore) ResolveDigest(pullspec string) (string, error) {
 	id, err := repo.store.Lookup(pullspec)
 	if err != nil {
 		return "", fmt.Errorf("%w %q: %w", ErrPullspecResolve, pullspec, err)

--- a/pkg/imagestore/imagestore.go
+++ b/pkg/imagestore/imagestore.go
@@ -34,18 +34,18 @@ var ErrBuildahStorageSetup = errors.New("error while setting up buildah storage"
 func NewBuildahStore() (ImageStore, error) {
 	// The containers/storage library requires this to run for some operations
 	if reexec.Init() {
-		return &BuildahStore{}, fmt.Errorf("%w: failed to init reexec", ErrBuildahStorageSetup)
+		return nil, fmt.Errorf("%w: failed to init reexec", ErrBuildahStorageSetup)
 	}
 
 	opts, err := storage.DefaultStoreOptions()
 	if err != nil {
-		return &BuildahStore{},
+		return nil,
 			fmt.Errorf("%w: failed to create default storage options: %w", ErrBuildahStorageSetup, err)
 	}
 
 	store, err := storage.GetStore(opts)
 	if err != nil {
-		return &BuildahStore{}, fmt.Errorf("%w: failed to create storage: %w", ErrBuildahStorageSetup, err)
+		return nil, fmt.Errorf("%w: failed to create storage: %w", ErrBuildahStorageSetup, err)
 	}
 
 	return &BuildahStore{

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -3,14 +3,14 @@
 package capo
 
 import (
-	"encoding/json"
 	"errors"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/konflux-ci/capo/pkg/containerfile"
 	"github.com/magefile/mage/sh"
 	"go.podman.io/storage"
 	"os"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -52,8 +52,22 @@ func (testCase *TestCase) run(t *testing.T, store storage.Store) error {
 	if err != nil {
 		return err
 	}
-	if !comparePackagesOrderIndependent(testCase.ExpectedResult.Packages, result.Packages, t) {
-		t.Errorf("package comparison failed")
+	// Compare packages order-independently using go-cmp:
+	// - SortSlices: ensures comparison is order-independent by sorting on PackageURL
+	// - EquateEmpty: treats nil and empty slices as equal
+	// - FilterPath on Pullspec: strips @sha256: digests before comparing pullspecs,
+	//   since actual digests vary between builds and should not cause test failures
+	diff := cmp.Diff(testCase.ExpectedResult.Packages, result.Packages,
+		cmpopts.SortSlices(func(a, b PackageMetadataItem) bool { return a.PackageURL < b.PackageURL }),
+		cmpopts.EquateEmpty(),
+		cmp.FilterPath(func(p cmp.Path) bool {
+			return p.String() == "Pullspec"
+		}, cmp.Comparer(func(a, b string) bool {
+			return normalizePullspec(a) == normalizePullspec(b)
+		})),
+	)
+	if diff != "" {
+		t.Errorf("package comparison mismatch (-want +got):\n%s", diff)
 		return errors.New("package comparison failed")
 	}
 	return nil
@@ -100,102 +114,11 @@ func (buildDef *BuildDefinition) buildImage(store storage.Store, isBuilder bool)
 	return sh.RunV("buildah", args...)
 }
 
-// normalizePullspecForComparison extracts the image reference part from a pullspec,
-// removing the digest portion for flexible comparison in tests.
-func normalizePullspecForComparison(pullspec string) string {
+func normalizePullspec(pullspec string) string {
 	if atIndex := strings.Index(pullspec, "@sha256:"); atIndex != -1 {
 		return pullspec[:atIndex]
 	}
 	return pullspec
-}
-
-// createPackageKey creates a unique key for a package based on its identifying fields
-func createPackageKey(pkg PackageMetadataItem) (string, error) {
-	// Sort the Checksums slice to ensure consistent ordering of slices
-	if len(pkg.Checksums) > 1 {
-		sort.Strings(pkg.Checksums)
-	}
-
-	// Create a copy of the package with normalized pullspec for key generation
-	normalizedPkg := pkg
-	normalizedPkg.Pullspec = normalizePullspecForComparison(pkg.Pullspec)
-
-	// Use JSON marshalling to create a unique key that includes all fields
-	// This is more robust than manual string concatenation and handles edge cases
-	jsonBytes, err := json.Marshal(normalizedPkg)
-	if err != nil {
-		return "", err
-	}
-	return string(jsonBytes), nil
-}
-
-// countPackages counts occurrences of each package in the slice and returns
-// a map keyed by package JSON with values being the count. This is able to track
-// even duplicated packages created by a Syft scan by keeping the number of occurrences
-// in the resulting map.
-func countPackages(packages []PackageMetadataItem) map[string]int {
-	countMap := make(map[string]int)
-	for _, pkg := range packages {
-		key, err := createPackageKey(pkg)
-		if err != nil {
-			continue
-		}
-		countMap[key]++
-	}
-	return countMap
-}
-
-// comparePackagesOrderIndependent compares two package slices ignoring order.
-// Returns true if they contain the same packages. Logs detailed differences on failure.
-func comparePackagesOrderIndependent(expected, actual []PackageMetadataItem, t *testing.T) bool {
-	result := true
-	if len(expected) != len(actual) {
-		t.Logf("Length mismatch: expected %d packages, got %d packages", len(expected), len(actual))
-		result = false
-	}
-
-	expectedMap := countPackages(expected)
-	actualMap := countPackages(actual)
-	// Compare the maps and log differences
-	if len(expectedMap) != len(actualMap) {
-		t.Logf("Different number of unique package types: expected %d, got %d", len(expectedMap), len(actualMap))
-		result = false
-	}
-
-	// Find missing packages (in expected but not in actual)
-	missingCount := 0
-	for key, expectedCount := range expectedMap {
-		if actualCount, exists := actualMap[key]; !exists {
-			t.Logf("Missing package: %s (expected %d instances)", key, expectedCount)
-			missingCount++
-			result = false
-		} else if expectedCount > actualCount {
-			t.Logf("Missing %d instances of package: %s (expected %d, got %d)", expectedCount-actualCount, key, expectedCount, actualCount)
-			missingCount++
-			result = false
-		}
-	}
-
-	// Find extra packages (in actual but not in expected)
-	extraCount := 0
-	for key, actualCount := range actualMap {
-		if expectedCount, exists := expectedMap[key]; !exists {
-			t.Logf("Extra package: %s (found %d instances)", key, actualCount)
-			extraCount++
-			result = false
-		} else if actualCount > expectedCount {
-			t.Logf("Extra %d instances of package: %s (expected %d, got %d)", actualCount-expectedCount, key, expectedCount, actualCount)
-			extraCount++
-			result = false
-		}
-	}
-
-	// Log summary
-	if missingCount > 0 || extraCount > 0 {
-		t.Logf("Package comparison summary: %d missing, %d extra", missingCount, extraCount)
-	}
-
-	return result
 }
 
 // cleanUpIntermediateLayers deletes all images without names/tags from the store.

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/konflux-ci/capo/pkg/containerfile"
@@ -75,20 +76,101 @@ func Probe(opts ProbeOpts, repo repository.Repository) (BuildMetadata, error) {
 		return meta, fmt.Errorf("%w: %w", ErrParseContainerfile, err)
 	}
 
-	baseImages, err := resolveBaseImages(repo, stages)
+	reachable := reachableStages(stages)
+
+	baseImages, err := resolveBaseImages(repo, reachable)
 	if err != nil {
 		return meta, err
 	}
 
 	meta.BaseImages = baseImages
 
-	extraImages, err := resolveExtraImages(repo, stages)
+	extraImages, err := resolveExtraImages(repo, reachable)
 	if err != nil {
 		return meta, err
 	}
 	meta.ExtraImages = extraImages
 
 	return meta, nil
+}
+
+// reachableStages returns only the stages transitively reachable (via BFS) from the
+// final stage via FROM, COPY --from, and RUN --mount references.
+func reachableStages(stages []containerfile.Stage) []containerfile.Stage {
+	if len(stages) == 0 {
+		return stages
+	}
+
+	// Map stage aliases to all their indexes. Multiple stages can share the
+	// same alias. Buildah builds all matching stages, so we must track every
+	// occurrence. The final stage has Alias==FinalStage so it won't collide
+	// with named builder stages.
+	stagesByAlias := make(map[string][]int)
+	for stageIndex, stage := range stages {
+		stagesByAlias[stage.Alias] = append(stagesByAlias[stage.Alias], stageIndex)
+	}
+
+	// findMatchingStages returns all stage indexes that match a reference,
+	// either by alias or by numeric index.
+	findMatchingStages := func(ref string) ([]int, bool) {
+		if indexes, ok := stagesByAlias[ref]; ok {
+			return indexes, true
+		}
+		if stageIndex, err := strconv.Atoi(ref); err == nil && 0 <= stageIndex && stageIndex < len(stages) {
+			return []int{stageIndex}, true
+		}
+		return nil, false
+	}
+
+	isReachable := make([]bool, len(stages))
+	stagesToProcess := []int{len(stages) - 1}
+	isReachable[len(stages)-1] = true
+
+	enqueue := func(stageIndex int) {
+		if !isReachable[stageIndex] {
+			isReachable[stageIndex] = true
+			stagesToProcess = append(stagesToProcess, stageIndex)
+		}
+	}
+
+	for len(stagesToProcess) > 0 {
+		stageIndex := stagesToProcess[0]
+		stagesToProcess = stagesToProcess[1:]
+		stage := stages[stageIndex]
+
+		for _, ref := range stageRefs(stage) {
+			if matches, ok := findMatchingStages(ref); ok {
+				for _, matchIndex := range matches {
+					enqueue(matchIndex)
+				}
+			}
+		}
+	}
+
+	reachableStages := make([]containerfile.Stage, 0, len(stages))
+	for stageIndex, stage := range stages {
+		if isReachable[stageIndex] {
+			reachableStages = append(reachableStages, stage)
+		}
+	}
+	return reachableStages
+}
+
+// stageRefs returns all references to other stages from a given stage:
+// the FROM base image and all builder-type COPY --from and RUN --mount refs.
+func stageRefs(stage containerfile.Stage) []string {
+	refs := []string{stage.Base}
+	for _, cp := range stage.Copies {
+		if cp.Type == containerfile.CopyTypeBuilder {
+			refs = append(refs, cp.From)
+		}
+	}
+	for _, mount := range stage.Mounts {
+		if mount.Type == containerfile.MountTypeBuilder {
+			refs = append(refs, mount.From)
+		}
+	}
+	return refs
 }
 
 func resolveBaseImages(repo repository.Repository, stages []containerfile.Stage) ([]Image, error) {

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -1,3 +1,6 @@
+// Package probe extracts build metadata from a Containerfile without
+// performing a build. It parses the Containerfile, identifies base and extra
+// images, and optionally resolves their digests via a Repository.
 package probe
 
 import (
@@ -10,17 +13,23 @@ import (
 	"github.com/konflux-ci/capo/pkg/repository"
 )
 
+// Image represents a container image identified by its pullspec and,
+// when resolved, its content digest.
 type Image struct {
 	Pullspec string
 	Digest   string
 }
 
+// BuildMetadata holds the images involved in a container build: the built
+// image itself, its base images (FROM lines), and any extra images referenced
+// via COPY --from or RUN --mount.
 type BuildMetadata struct {
 	Image       Image   `yaml:"image"`
 	BaseImages  []Image `yaml:"base_images"`
 	ExtraImages []Image `yaml:"extra_images"`
 }
 
+// ProbeOpts configures a Probe invocation.
 type ProbeOpts struct {
 	// Tag of the built image
 	// If empty, the built image won't be resolved.
@@ -33,9 +42,14 @@ type ProbeOpts struct {
 	Args map[string]string
 }
 
+// ErrParseContainerfile is returned when the Containerfile cannot be parsed.
 var ErrParseContainerfile = errors.New("could not parse containerfile")
+
+// ErrDigestResolve is returned when an image digest cannot be resolved.
 var ErrDigestResolve = errors.New("failed to resolve digest of image")
 
+// Probe parses the Containerfile described in opts and collects build metadata.
+// When repo is non-nil, image digests are resolved through the repository.
 func Probe(opts ProbeOpts, repo repository.Repository) (BuildMetadata, error) {
 	meta := BuildMetadata{}
 

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -17,7 +17,9 @@ import (
 // Image represents a container image identified by its pullspec and,
 // when resolved, its content digest.
 type Image struct {
+	// Pullspec of the image as found in the Containerfile
 	Pullspec string
+	// Digest in the form sha256:<digest>
 	Digest   string
 }
 
@@ -33,7 +35,6 @@ type BuildMetadata struct {
 // ProbeOpts configures a Probe invocation.
 type ProbeOpts struct {
 	// Tag of the built image
-	// If empty, the built image won't be resolved.
 	Tag string
 	// Reader of the containerfile
 	Containerfile io.Reader

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -20,7 +20,7 @@ type Image struct {
 	// Pullspec of the image as found in the Containerfile
 	Pullspec string
 	// Digest in the form sha256:<digest>
-	Digest   string
+	Digest string
 }
 
 // BuildMetadata holds the images involved in a container build: the built

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -113,31 +113,46 @@ func resolveExtraImages(repo repository.Repository, stages []containerfile.Stage
 	res := make([]Image, 0)
 	seen := make(map[string]bool)
 
+	addImage := func(pullspec string) error {
+		if seen[pullspec] {
+			return nil
+		}
+		seen[pullspec] = true
+
+		digest := ""
+		var err error
+
+		if repo != nil {
+			digest, err = repo.ResolveDigest(pullspec)
+			if err != nil {
+				return fmt.Errorf("%w %q: %w", ErrDigestResolve, pullspec, err)
+			}
+		}
+
+		res = append(res, Image{
+			Pullspec: pullspec,
+			Digest:   digest,
+		})
+		return nil
+	}
+
 	for _, stage := range stages {
 		for _, cp := range stage.Copies {
 			if cp.Type != containerfile.CopyTypeExternal {
 				continue
 			}
+			if err := addImage(cp.From); err != nil {
+				return nil, err
+			}
+		}
 
-			if seen[cp.From] {
+		for _, mount := range stage.Mounts {
+			if mount.Type != containerfile.MountTypeExternal {
 				continue
 			}
-			seen[cp.From] = true
-
-			digest := ""
-			var err error
-
-			if repo != nil {
-				digest, err = repo.ResolveDigest(cp.From)
-				if err != nil {
-					return nil, fmt.Errorf("%w %q: %w", ErrDigestResolve, stage.Base, err)
-				}
+			if err := addImage(mount.From); err != nil {
+				return nil, err
 			}
-
-			res = append(res, Image{
-				Pullspec: cp.From,
-				Digest:   digest,
-			})
 		}
 	}
 

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -1,0 +1,145 @@
+package probe
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/konflux-ci/capo/pkg/containerfile"
+	"github.com/konflux-ci/capo/pkg/repository"
+)
+
+type Image struct {
+	Pullspec string
+	Digest   string
+}
+
+type BuildMetadata struct {
+	Image       Image   `yaml:"image"`
+	BaseImages  []Image `yaml:"base_images"`
+	ExtraImages []Image `yaml:"extra_images"`
+}
+
+type ProbeOpts struct {
+	// Tag of the built image
+	// If empty, the built image won't be resolved.
+	Tag string
+	// Reader of the containerfile
+	Containerfile io.Reader
+	// Target stage of the build
+	Target string
+	// Build args
+	Args map[string]string
+}
+
+var ErrParseContainerfile = errors.New("could not parse containerfile")
+var ErrDigestResolve = errors.New("failed to resolve digest of image")
+
+func Probe(opts ProbeOpts, repo repository.Repository) (BuildMetadata, error) {
+	meta := BuildMetadata{}
+
+	meta.Image.Pullspec = opts.Tag
+
+	if repo != nil {
+		digest, err := repo.ResolveDigest(opts.Tag)
+		if err != nil {
+			return meta, fmt.Errorf("%w %q: %w", ErrDigestResolve, opts.Tag, err)
+		}
+
+		meta.Image.Digest = digest
+	}
+
+	stages, err := containerfile.Parse(
+		opts.Containerfile,
+		containerfile.BuildOptions{
+			Args:   opts.Args,
+			Target: opts.Target,
+		},
+	)
+	if err != nil {
+		return meta, fmt.Errorf("%w: %w", ErrParseContainerfile, err)
+	}
+
+	baseImages, err := resolveBaseImages(repo, stages)
+	if err != nil {
+		return meta, err
+	}
+
+	meta.BaseImages = baseImages
+
+	extraImages, err := resolveExtraImages(repo, stages)
+	if err != nil {
+		return meta, err
+	}
+	meta.ExtraImages = extraImages
+
+	return meta, nil
+}
+
+func resolveBaseImages(repo repository.Repository, stages []containerfile.Stage) ([]Image, error) {
+	res := make([]Image, 0)
+	seen := make(map[string]bool)
+
+	for _, stage := range stages {
+		if stage.Base == "scratch" || strings.HasPrefix(stage.Base, "oci:archive") {
+			continue
+		}
+
+		if seen[stage.Base] {
+			continue
+		}
+		seen[stage.Base] = true
+
+		digest := ""
+		var err error
+
+		if repo != nil {
+			digest, err = repo.ResolveDigest(stage.Base)
+			if err != nil {
+				return nil, fmt.Errorf("%w %q: %w", ErrDigestResolve, stage.Base, err)
+			}
+		}
+		res = append(res, Image{
+			Pullspec: stage.Base,
+			Digest:   digest,
+		})
+	}
+
+	return res, nil
+}
+
+func resolveExtraImages(repo repository.Repository, stages []containerfile.Stage) ([]Image, error) {
+	res := make([]Image, 0)
+	seen := make(map[string]bool)
+
+	for _, stage := range stages {
+		for _, cp := range stage.Copies {
+			if cp.Type != containerfile.CopyTypeExternal {
+				continue
+			}
+
+			if seen[cp.From] {
+				continue
+			}
+			seen[cp.From] = true
+
+			digest := ""
+			var err error
+
+			if repo != nil {
+				digest, err = repo.ResolveDigest(cp.From)
+				if err != nil {
+					return nil, fmt.Errorf("%w %q: %w", ErrDigestResolve, stage.Base, err)
+				}
+			}
+
+			res = append(res, Image{
+				Pullspec: cp.From,
+				Digest:   digest,
+			})
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -1,6 +1,6 @@
 // Package probe extracts build metadata from a Containerfile without
 // performing a build. It parses the Containerfile, identifies base and extra
-// images, and optionally resolves their digests via a Repository.
+// images, and optionally resolves their digests via an ImageStore.
 package probe
 
 import (
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/konflux-ci/capo/pkg/containerfile"
-	"github.com/konflux-ci/capo/pkg/repository"
+	"github.com/konflux-ci/capo/pkg/imagestore"
 )
 
 // Image represents a container image identified by its pullspec and,
@@ -50,14 +50,14 @@ var ErrParseContainerfile = errors.New("could not parse containerfile")
 var ErrDigestResolve = errors.New("failed to resolve digest of image")
 
 // Probe parses the Containerfile described in opts and collects build metadata.
-// When repo is non-nil, image digests are resolved through the repository.
-func Probe(opts ProbeOpts, repo repository.Repository) (BuildMetadata, error) {
+// When repo is non-nil, image digests are resolved through the image store.
+func Probe(opts ProbeOpts, store imagestore.ImageStore) (BuildMetadata, error) {
 	meta := BuildMetadata{}
 
 	meta.Image.Pullspec = opts.Tag
 
-	if repo != nil {
-		digest, err := repo.ResolveDigest(opts.Tag)
+	if store != nil {
+		digest, err := store.ResolveDigest(opts.Tag)
 		if err != nil {
 			return meta, fmt.Errorf("%w %q: %w", ErrDigestResolve, opts.Tag, err)
 		}
@@ -78,14 +78,14 @@ func Probe(opts ProbeOpts, repo repository.Repository) (BuildMetadata, error) {
 
 	reachable := reachableStages(stages)
 
-	baseImages, err := resolveBaseImages(repo, reachable)
+	baseImages, err := resolveBaseImages(store, reachable)
 	if err != nil {
 		return meta, err
 	}
 
 	meta.BaseImages = baseImages
 
-	extraImages, err := resolveExtraImages(repo, reachable)
+	extraImages, err := resolveExtraImages(store, reachable)
 	if err != nil {
 		return meta, err
 	}
@@ -173,7 +173,7 @@ func stageRefs(stage containerfile.Stage) []string {
 	return refs
 }
 
-func resolveBaseImages(repo repository.Repository, stages []containerfile.Stage) ([]Image, error) {
+func resolveBaseImages(store imagestore.ImageStore, stages []containerfile.Stage) ([]Image, error) {
 	res := make([]Image, 0)
 	seen := make(map[string]bool)
 
@@ -190,8 +190,8 @@ func resolveBaseImages(repo repository.Repository, stages []containerfile.Stage)
 		digest := ""
 		var err error
 
-		if repo != nil {
-			digest, err = repo.ResolveDigest(stage.Base)
+		if store != nil {
+			digest, err = store.ResolveDigest(stage.Base)
 			if err != nil {
 				return nil, fmt.Errorf("%w %q: %w", ErrDigestResolve, stage.Base, err)
 			}
@@ -205,7 +205,7 @@ func resolveBaseImages(repo repository.Repository, stages []containerfile.Stage)
 	return res, nil
 }
 
-func resolveExtraImages(repo repository.Repository, stages []containerfile.Stage) ([]Image, error) {
+func resolveExtraImages(store imagestore.ImageStore, stages []containerfile.Stage) ([]Image, error) {
 	res := make([]Image, 0)
 	seen := make(map[string]bool)
 
@@ -218,8 +218,8 @@ func resolveExtraImages(repo repository.Repository, stages []containerfile.Stage
 		digest := ""
 		var err error
 
-		if repo != nil {
-			digest, err = repo.ResolveDigest(pullspec)
+		if store != nil {
+			digest, err = store.ResolveDigest(pullspec)
 			if err != nil {
 				return fmt.Errorf("%w %q: %w", ErrDigestResolve, pullspec, err)
 			}

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -192,6 +192,64 @@ func TestProbe(t *testing.T) {
 				ExtraImages: []Image{},
 			},
 		},
+		// The following test exists to match inconsistent behaviour in buildah:
+		// https://github.com/containers/buildah/issues/6731
+		"duplicate stage names reports both base images": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							COPY . .
+							FROM quay.io/fedora:42 AS builder
+							COPY . .
+							FROM scratch
+							COPY --from=builder /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/fedora:42":    "fedoradigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+					{Pullspec: "quay.io/fedora:42", Digest: "fedoradigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
+		"duplicate stage names with target matches first stage": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							COPY . .
+							FROM quay.io/fedora:42 AS builder
+							COPY . .
+							FROM scratch
+							COPY --from=builder /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "builder",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -209,7 +267,7 @@ func TestProbe(t *testing.T) {
 				t.Fatalf("Probe returned unexpected error: %v", err)
 			}
 
-			if diff := cmp.Diff(actual, test.expected); diff != "" {
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
 				t.Errorf("Probe() result mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-type TestRepository struct {
+type TestStore struct {
 	digests map[string]string
 }
 
-func (repo TestRepository) ResolveDigest(pullspec string) (string, error) {
-	return repo.digests[pullspec], nil
+func (store TestStore) ResolveDigest(pullspec string) (string, error) {
+	return store.digests[pullspec], nil
 }
 
 func TestProbe(t *testing.T) {
@@ -369,7 +369,7 @@ func TestProbe(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			repo := TestRepository{
+			repo := TestStore{
 				digests: test.digests,
 			}
 

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -28,7 +28,10 @@ func TestProbe(t *testing.T) {
 	}{
 		"simple": {
 			containerfile: `FROM quay.io/rhel:9 as builder
-							FROM quay.io/fedora:42`,
+							WORKDIR /app
+							COPY . .
+							FROM quay.io/fedora:42
+							COPY --from=builder /app /app`,
 			opts: ProbeOpts{
 				Tag:    "quay.io/image:latest",
 				Target: "",
@@ -287,6 +290,36 @@ func TestProbe(t *testing.T) {
 				Args:   make(map[string]string),
 			},
 			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/fedora:42":    "fedoradigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+					{Pullspec: "quay.io/fedora:42", Digest: "fedoradigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
+		"unreachable stage is excluded when target is set": {
+			containerfile: `FROM quay.io/alpine:3 AS unreachable
+							RUN echo hello
+							FROM quay.io/rhel:9 AS builder
+							COPY . .
+							FROM quay.io/fedora:42
+							COPY --from=builder /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/alpine:3":     "alpinedigest",
 				"quay.io/rhel:9":       "rheldigest",
 				"quay.io/fedora:42":    "fedoradigest",
 				"quay.io/image:latest": "imagedigest",

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -192,6 +192,86 @@ func TestProbe(t *testing.T) {
 				ExtraImages: []Image{},
 			},
 		},
+		"extra image from RUN --mount=from": {
+			containerfile: `FROM quay.io/rhel:9
+							RUN --mount=type=bind,from=quay.io/tools:1,src=/bin/tool,dst=/tmp/tool /tmp/tool --version`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/tools:1":      "toolsdigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+				},
+				ExtraImages: []Image{
+					{Pullspec: "quay.io/tools:1", Digest: "toolsdigest"},
+				},
+			},
+		},
+		"RUN --mount=from builder stage is not an extra image": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							FROM quay.io/fedora:42
+							RUN --mount=type=bind,from=builder,src=/app,dst=/app ls /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/fedora:42":    "fedoradigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+					{Pullspec: "quay.io/fedora:42", Digest: "fedoradigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
+		"COPY --from numeric stage index is builder image": {
+			containerfile: `FROM quay.io/rhel:9
+							WORKDIR /app
+							COPY . .
+							FROM quay.io/fedora:42
+							COPY --from=0 /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/fedora:42":    "fedoradigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+					{Pullspec: "quay.io/fedora:42", Digest: "fedoradigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
 		// The following test exists to match inconsistent behaviour in buildah:
 		// https://github.com/containers/buildah/issues/6731
 		"duplicate stage names reports both base images": {

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -1,0 +1,217 @@
+//go:build unit
+
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type TestRepository struct {
+	digests map[string]string
+}
+
+func (repo TestRepository) ResolveDigest(pullspec string) (string, error) {
+	return repo.digests[pullspec], nil
+}
+
+func TestProbe(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		containerfile string
+		opts          ProbeOpts
+		digests       map[string]string
+		expected      BuildMetadata
+	}{
+		"simple": {
+			containerfile: `FROM quay.io/rhel:9 as builder
+							FROM quay.io/fedora:42`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/fedora:42":    "fedoradigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{
+						Pullspec: "quay.io/rhel:9",
+						Digest:   "rheldigest",
+					},
+					{
+						Pullspec: "quay.io/fedora:42",
+						Digest:   "fedoradigest",
+					},
+				},
+				ExtraImages: []Image{},
+			},
+		},
+		"extra image from COPY --from": {
+			containerfile: `FROM quay.io/rhel:9
+							COPY --from=quay.io/tools:1 /bin/tool /usr/bin/tool`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/tools:1":      "toolsdigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+				},
+				ExtraImages: []Image{
+					{Pullspec: "quay.io/tools:1", Digest: "toolsdigest"},
+				},
+			},
+		},
+		"COPY --from builder stage is not an extra image": {
+			containerfile: `FROM quay.io/rhel:9 as builder
+							WORKDIR /app
+							COPY . .
+							FROM quay.io/fedora:42
+							COPY --from=builder /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/fedora:42":    "fedoradigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+					{Pullspec: "quay.io/fedora:42", Digest: "fedoradigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
+		"duplicate base and extra images are deduplicated": {
+			containerfile: `FROM quay.io/rhel:9 as builder
+							COPY --from=quay.io/tools:1 /bin/tool1 /usr/bin/tool1
+							COPY --from=quay.io/tools:1 /bin/tool2 /usr/bin/tool2
+							COPY --from=quay.io/utils:2 /bin/util /usr/bin/util
+							FROM quay.io/rhel:9
+							COPY --from=quay.io/tools:1 /bin/tool /usr/bin/tool
+							COPY --from=quay.io/utils:2 /bin/util /usr/bin/util`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/tools:1":      "toolsdigest",
+				"quay.io/utils:2":      "utilsdigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+				},
+				ExtraImages: []Image{
+					{Pullspec: "quay.io/tools:1", Digest: "toolsdigest"},
+					{Pullspec: "quay.io/utils:2", Digest: "utilsdigest"},
+				},
+			},
+		},
+		"scratch base is excluded from base images": {
+			containerfile: `FROM quay.io/rhel:9 as builder
+							FROM scratch
+							COPY --from=builder /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
+		"oci:archive base is excluded from base images": {
+			containerfile: `FROM quay.io/rhel:9 as builder
+							FROM oci:archive:/path/to/archive
+							COPY --from=builder /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]string{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+				},
+				ExtraImages: []Image{},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := TestRepository{
+				digests: test.digests,
+			}
+
+			test.opts.Containerfile = strings.NewReader(test.containerfile)
+
+			actual, err := Probe(test.opts, repo)
+			if err != nil {
+				t.Fatalf("Probe returned unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(actual, test.expected); diff != "" {
+				t.Errorf("Probe() result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,0 +1,58 @@
+package repository
+
+// FIXME: add documentation in this package
+
+import (
+	"errors"
+	"fmt"
+
+	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/reexec"
+)
+
+type Repository interface {
+	ResolveDigest(string) (string, error)
+}
+
+type BuildahRepository struct {
+	store storage.Store
+}
+
+var ErrPullspecResolve = errors.New("failed to resolve pullspec")
+var ErrBuildahStorageSetup = errors.New("error while setting up buildah storage")
+
+func NewBuildahRepository() (Repository, error) {
+	// The containers/storage library requires this to run for some operations
+	if reexec.Init() {
+		return &BuildahRepository{}, fmt.Errorf("%w: failed to init reexec", ErrBuildahStorageSetup)
+	}
+
+	opts, err := storage.DefaultStoreOptions()
+	if err != nil {
+		return &BuildahRepository{},
+			fmt.Errorf("%w: failed to create default storage options: %w", ErrBuildahStorageSetup, err)
+	}
+
+	store, err := storage.GetStore(opts)
+	if err != nil {
+		return &BuildahRepository{}, fmt.Errorf("%w: failed to create storage: %w", ErrBuildahStorageSetup, err)
+	}
+
+	return &BuildahRepository{
+		store: store,
+	}, nil
+}
+
+func (repo *BuildahRepository) ResolveDigest(pullspec string) (string, error) {
+	id, err := repo.store.Lookup(pullspec)
+	if err != nil {
+		return "", fmt.Errorf("%w %q: %w", ErrPullspecResolve, pullspec, err)
+	}
+
+	img, err := repo.store.Image(id)
+	if err != nil {
+		return "", fmt.Errorf("%w %q: %w", ErrPullspecResolve, pullspec, err)
+	}
+
+	return fmt.Sprintf("sha256:%s", img.Digest.Encoded()), nil
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,6 +1,6 @@
+// Package repository provides access to container image storage for resolving
+// image pullspecs to their digests.
 package repository
-
-// FIXME: add documentation in this package
 
 import (
 	"errors"
@@ -10,17 +10,27 @@ import (
 	"go.podman.io/storage/pkg/reexec"
 )
 
+// Repository abstracts container image storage operations, primarily the
+// resolution of image pullspecs to their content digests.
 type Repository interface {
 	ResolveDigest(string) (string, error)
 }
 
+// BuildahRepository is a Repository backed by a local buildah/containers storage.
 type BuildahRepository struct {
 	store storage.Store
 }
 
+// ErrPullspecResolve is returned when a pullspec cannot be found or resolved
+// in the storage.
 var ErrPullspecResolve = errors.New("failed to resolve pullspec")
+
+// ErrBuildahStorageSetup is returned when the buildah storage cannot be
+// initialized.
 var ErrBuildahStorageSetup = errors.New("error while setting up buildah storage")
 
+// NewBuildahRepository creates a BuildahRepository using the default
+// containers/storage location.
 func NewBuildahRepository() (Repository, error) {
 	// The containers/storage library requires this to run for some operations
 	if reexec.Init() {
@@ -43,6 +53,8 @@ func NewBuildahRepository() (Repository, error) {
 	}, nil
 }
 
+// ResolveDigest looks up the given pullspec in the local storage and returns
+// its content digest in the form "sha256:<hex>".
 func (repo *BuildahRepository) ResolveDigest(pullspec string) (string, error) {
 	id, err := repo.store.Lookup(pullspec)
 	if err != nil {

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -355,7 +355,7 @@ func getPackageMetadata(
 	builderPkgs []sbom.SyftPackage,
 	intermediatePkgs []sbom.SyftPackage,
 ) []PackageMetadataItem {
-	res := make([]PackageMetadataItem, 0, len(builderPkgs) + len(intermediatePkgs))
+	res := make([]PackageMetadataItem, 0, len(builderPkgs)+len(intermediatePkgs))
 
 	for _, bpkg := range builderPkgs {
 		res = append(res, PackageMetadataItem{

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -229,10 +229,10 @@ func getPackageSources(
 		}
 
 		res = append(res, packageSource{
-			alias:          stage.Alias,
-			pullspec:       stage.Base,
+			alias:      stage.Alias,
+			pullspec:   stage.Base,
 			digestBase: digestPullspec,
-			sources:        stageToSources[stage],
+			sources:    stageToSources[stage],
 		})
 
 		// the processed stage must be deleted from stageToSources so it only
@@ -250,10 +250,10 @@ func getPackageSources(
 		}
 
 		res = append(res, packageSource{
-			alias:          stage.Alias,
-			pullspec:       stage.Base,
+			alias:      stage.Alias,
+			pullspec:   stage.Base,
 			digestBase: digestPullspec,
-			sources:        sources,
+			sources:    sources,
 		})
 	}
 

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -125,13 +125,13 @@ func resolvePullspecs(store storage.Store, stages []containerfile.Stage) (map[st
 	res := make(map[string]string)
 
 	for _, stage := range stages[:len(stages)-1] {
-		if _, ok := res[stage.Pullspec]; !ok {
-			resolved, err := resolvePullspec(store, stage.Pullspec)
+		if _, ok := res[stage.Base]; !ok {
+			resolved, err := resolvePullspec(store, stage.Base)
 			if err != nil {
 				return nil, err
 			}
 
-			res[stage.Pullspec] = resolved
+			res[stage.Base] = resolved
 		}
 	}
 
@@ -209,9 +209,9 @@ func getPackageSources(
 				traceSource(source, aliasToStage[cp.From], stageToSources, aliasToStage)
 			} else {
 				external := containerfile.Stage{
-					Alias:    "",
-					Pullspec: cp.From,
-					Copies:   []containerfile.Copy{},
+					Alias:  "",
+					Base:   cp.From,
+					Copies: []containerfile.Copy{},
 				}
 				stageToSources[&external] = append(stageToSources[&external], source)
 			}
@@ -222,15 +222,15 @@ func getPackageSources(
 	for i := range stages[:len(stages)-1] {
 		stage := &stages[i]
 
-		digestPullspec, ok := resolvedPullspecs[stage.Pullspec]
+		digestPullspec, ok := resolvedPullspecs[stage.Base]
 		if !ok {
 			return []packageSource{},
-				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Pullspec)
+				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Base)
 		}
 
 		res = append(res, packageSource{
 			alias:          stage.Alias,
-			pullspec:       stage.Pullspec,
+			pullspec:       stage.Base,
 			digestPullspec: digestPullspec,
 			sources:        stageToSources[stage],
 		})
@@ -243,15 +243,15 @@ func getPackageSources(
 
 	// construct external package sources
 	for stage, sources := range stageToSources {
-		digestPullspec, ok := resolvedPullspecs[stage.Pullspec]
+		digestPullspec, ok := resolvedPullspecs[stage.Base]
 		if !ok {
 			return []packageSource{},
-				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Pullspec)
+				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Base)
 		}
 
 		res = append(res, packageSource{
 			alias:          stage.Alias,
-			pullspec:       stage.Pullspec,
+			pullspec:       stage.Base,
 			digestPullspec: digestPullspec,
 			sources:        sources,
 		})

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -25,8 +25,8 @@ type packageSource struct {
 	// Pullspec of this stage as it appeared in the containerfile.
 	pullspec string
 
-	// Pullspec of this stage with digest instead of tag.
-	digestPullspec string
+	// Pullspec of the base of this stage with digest instead of tag.
+	digestBase string
 
 	// Slice of paths to content in the layer/image which should be syft-scanned
 	sources []string
@@ -231,7 +231,7 @@ func getPackageSources(
 		res = append(res, packageSource{
 			alias:          stage.Alias,
 			pullspec:       stage.Base,
-			digestPullspec: digestPullspec,
+			digestBase: digestPullspec,
 			sources:        stageToSources[stage],
 		})
 
@@ -252,7 +252,7 @@ func getPackageSources(
 		res = append(res, packageSource{
 			alias:          stage.Alias,
 			pullspec:       stage.Base,
-			digestPullspec: digestPullspec,
+			digestBase: digestPullspec,
 			sources:        sources,
 		})
 	}
@@ -359,7 +359,7 @@ func getPackageMetadata(
 
 	for _, bpkg := range builderPkgs {
 		res = append(res, PackageMetadataItem{
-			Pullspec:         pkgSource.digestPullspec,
+			Pullspec:         pkgSource.digestBase,
 			StageAlias:       pkgSource.alias,
 			PackageURL:       bpkg.PURL,
 			DependencyOfPURL: bpkg.DependencyOfPURL,
@@ -370,7 +370,7 @@ func getPackageMetadata(
 
 	for _, ipkg := range intermediatePkgs {
 		res = append(res, PackageMetadataItem{
-			Pullspec:         pkgSource.digestPullspec,
+			Pullspec:         pkgSource.digestBase,
 			StageAlias:       pkgSource.alias,
 			PackageURL:       ipkg.PURL,
 			DependencyOfPURL: ipkg.DependencyOfPURL,

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -35,7 +35,7 @@ func comparePackageSources(a, b []packageSource) bool {
 
 // packageSourceEqual compares two packageSource structs
 func packageSourceEqual(a, b packageSource) bool {
-	if a.alias != b.alias || a.pullspec != b.pullspec || a.digestPullspec != b.digestPullspec {
+	if a.alias != b.alias || a.pullspec != b.pullspec || a.digestBase != b.digestBase {
 		return false
 	}
 

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -433,10 +433,10 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:    "builder",
-					pullspec: "docker.io/library/fedora:latest",
+					alias:          "builder",
+					pullspec:       "docker.io/library/fedora:latest",
 					digestPullspec: "docker.io/library/fedora@sha256:hij456",
-					sources:  []string{"/lib/*.so"},
+					sources:        []string{"/lib/*.so"},
 				},
 			},
 		},
@@ -472,20 +472,20 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			resolvedPullspecs: map[string]string{
 				"docker.io/library/fedora:latest": "docker.io/library/fedora@sha256:hij456",
-				"docker.io/alpine/helm:latest": "docker.io/library/alpine/helm@sha256:abcdef",
+				"docker.io/alpine/helm:latest":    "docker.io/library/alpine/helm@sha256:abcdef",
 			},
 			expected: []packageSource{
 				{
-					alias:    "builder1",
-					pullspec: "docker.io/library/fedora:latest",
+					alias:          "builder1",
+					pullspec:       "docker.io/library/fedora:latest",
 					digestPullspec: "docker.io/library/fedora@sha256:hij456",
-					sources:  []string{"/usr/lib/*.so"},
+					sources:        []string{"/usr/lib/*.so"},
 				},
 				{
-					alias:    "builder2",
-					pullspec: "docker.io/alpine/helm:latest",
+					alias:          "builder2",
+					pullspec:       "docker.io/alpine/helm:latest",
 					digestPullspec: "docker.io/library/alpine/helm@sha256:abcdef",
-					sources:  []string{"/libs/*.so"},
+					sources:        []string{"/libs/*.so"},
 				},
 			},
 		},
@@ -513,10 +513,10 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:    "builder",
-					pullspec: "docker.io/library/fedora:latest",
+					alias:          "builder",
+					pullspec:       "docker.io/library/fedora:latest",
 					digestPullspec: "docker.io/library/fedora@sha256:hij456",
-					sources:  []string{"/usr/bin/helm", "/lib/*.so", "/etc/config.txt"},
+					sources:        []string{"/usr/bin/helm", "/lib/*.so", "/etc/config.txt"},
 				},
 			},
 		},

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -3,54 +3,12 @@
 package capo
 
 import (
-	"slices"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/konflux-ci/capo/pkg/containerfile"
 )
-
-// comparePackageSources compares two slices of packageSource, ignoring order
-func comparePackageSources(a, b []packageSource) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	bMatched := make([]bool, len(b))
-	for _, aItem := range a {
-		found := false
-		for j, bItem := range b {
-			if !bMatched[j] && packageSourceEqual(aItem, bItem) {
-				bMatched[j] = true
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	return true
-}
-
-// packageSourceEqual compares two packageSource structs
-func packageSourceEqual(a, b packageSource) bool {
-	if a.alias != b.alias || a.pullspec != b.pullspec || a.digestBase != b.digestBase {
-		return false
-	}
-
-	if len(a.sources) != len(b.sources) {
-		return false
-	}
-
-	for _, aSource := range a.sources {
-		if !slices.Contains(b.sources, aSource) {
-			return false
-		}
-	}
-
-	return true
-}
 
 func TestGetPackageSources(t *testing.T) {
 	t.Parallel()
@@ -530,8 +488,14 @@ func TestGetPackageSources(t *testing.T) {
 				t.Fatalf("getPackageSources returned error: %v", err)
 			}
 
-			if !comparePackageSources(actual, test.expected) {
-				t.Fatalf("actual package sources %+v, don't match the expected %+v", actual, test.expected)
+			diff := cmp.Diff(
+				test.expected, actual,
+				cmp.AllowUnexported(packageSource{}),
+				cmpopts.SortSlices(func(a, b packageSource) bool { return a.alias < b.alias }),
+				cmpopts.EquateEmpty(),
+			)
+			if diff != "" {
+				t.Errorf("getPackageSources() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -62,8 +62,8 @@ func TestGetPackageSources(t *testing.T) {
 		"only external copy in final": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "docker.io/library/fedora:latest",
@@ -79,28 +79,28 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:abc123",
-					sources:        []string{"/usr/bin/oras"},
+					alias:      "",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:abc123",
+					sources:    []string{"/usr/bin/oras"},
 				},
 			},
 		},
 		"copies in final stage only": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder2",
+					Base:   "docker.io/alpine/helm:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -123,29 +123,29 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder1",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:def456",
-					sources:        []string{"/usr/bin/oras"},
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:def456",
+					sources:    []string{"/usr/bin/oras"},
 				},
 				{
-					alias:          "builder2",
-					pullspec:       "docker.io/alpine/helm:latest",
-					digestPullspec: "docker.io/alpine/helm@sha256:ghi789",
-					sources:        []string{"/usr/bin/helm"},
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@sha256:ghi789",
+					sources:    []string{"/usr/bin/helm"},
 				},
 			},
 		},
 		"recursive multi-stage file copy": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -156,8 +156,8 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -174,29 +174,29 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder1",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:jkl012",
-					sources:        []string{"/usr/bin/oras"},
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:jkl012",
+					sources:    []string{"/usr/bin/oras"},
 				},
 				{
-					alias:          "builder2",
-					pullspec:       "docker.io/alpine/helm:latest",
-					digestPullspec: "docker.io/alpine/helm@sha256:mno345",
-					sources:        []string{},
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@sha256:mno345",
+					sources:    []string{},
 				},
 			},
 		},
 		"recursive multi-stage file copy - mixed sources": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -207,8 +207,8 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -225,29 +225,29 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder1",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:pqr678",
-					sources:        []string{"/usr/bin/oras"},
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:pqr678",
+					sources:    []string{"/usr/bin/oras"},
 				},
 				{
-					alias:          "builder2",
-					pullspec:       "docker.io/alpine/helm:latest",
-					digestPullspec: "docker.io/alpine/helm@sha256:stu901",
-					sources:        []string{"/usr/bin/helm"},
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@sha256:stu901",
+					sources:    []string{"/usr/bin/helm"},
 				},
 			},
 		},
 		"multi-stage directory copy": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -264,8 +264,8 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -282,29 +282,29 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder1",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:vwx234",
-					sources:        []string{"/usr/bin/oras", "/bin/*"},
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:vwx234",
+					sources:    []string{"/usr/bin/oras", "/bin/*"},
 				},
 				{
-					alias:          "builder2",
-					pullspec:       "docker.io/alpine/helm:latest",
-					digestPullspec: "docker.io/alpine/helm@sha256:yza567",
-					sources:        []string{"/app/"},
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@sha256:yza567",
+					sources:    []string{"/app/"},
 				},
 			},
 		},
 		"ignore non-copied content": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -315,8 +315,8 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -333,29 +333,29 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder1",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:bcd890",
-					sources:        []string{},
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:bcd890",
+					sources:    []string{},
 				},
 				{
-					alias:          "builder2",
-					pullspec:       "docker.io/alpine/helm:latest",
-					digestPullspec: "docker.io/alpine/helm@sha256:efg123",
-					sources:        []string{"/app/"},
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@sha256:efg123",
+					sources:    []string{"/app/"},
 				},
 			},
 		},
 		"complex multi-stage with multiple final copies": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -366,8 +366,8 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -396,29 +396,29 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder1",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:hij456",
-					sources:        []string{"/lib/libc.so", "/usr/bin/kubectl"},
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:hij456",
+					sources:    []string{"/lib/libc.so", "/usr/bin/kubectl"},
 				},
 				{
-					alias:          "builder2",
-					pullspec:       "docker.io/alpine/helm:latest",
-					digestPullspec: "docker.io/alpine/helm@sha256:klm789",
-					sources:        []string{"/tools/", "/usr/bin/helm"},
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@sha256:klm789",
+					sources:    []string{"/tools/", "/usr/bin/helm"},
 				},
 			},
 		},
 		"wildcard copy in final stage": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder",
@@ -433,23 +433,23 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:hij456",
-					sources:        []string{"/lib/*.so"},
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:hij456",
+					sources:    []string{"/lib/*.so"},
 				},
 			},
 		},
 		"wildcard traced through multiple stages": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder1",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    "builder2",
-					Pullspec: "docker.io/alpine/helm:latest",
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -459,8 +459,8 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -476,29 +476,29 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder1",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:hij456",
-					sources:        []string{"/usr/lib/*.so"},
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:hij456",
+					sources:    []string{"/usr/lib/*.so"},
 				},
 				{
-					alias:          "builder2",
-					pullspec:       "docker.io/alpine/helm:latest",
-					digestPullspec: "docker.io/library/alpine/helm@sha256:abcdef",
-					sources:        []string{"/libs/*.so"},
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/library/alpine/helm@sha256:abcdef",
+					sources:    []string{"/libs/*.so"},
 				},
 			},
 		},
 		"mixed wildcards and regular files": {
 			stages: []containerfile.Stage{
 				{
-					Alias:    "builder",
-					Pullspec: "docker.io/library/fedora:latest",
-					Copies:   []containerfile.Copy{},
+					Alias:  "builder",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
 				},
 				{
-					Alias:    containerfile.FinalStage,
-					Pullspec: "",
+					Alias: containerfile.FinalStage,
+					Base:  "",
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder",
@@ -513,10 +513,10 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expected: []packageSource{
 				{
-					alias:          "builder",
-					pullspec:       "docker.io/library/fedora:latest",
-					digestPullspec: "docker.io/library/fedora@sha256:hij456",
-					sources:        []string{"/usr/bin/helm", "/lib/*.so", "/etc/config.txt"},
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:hij456",
+					sources:    []string{"/usr/bin/helm", "/lib/*.so", "/etc/config.txt"},
 				},
 			},
 		},


### PR DESCRIPTION
## Changes
- Added the `Probe` package to inspect Containerfiles and compile a data structure with used images and optionally their digests.
- Added the `buildprobe` binary to pass arguments to the `Probe` package and output used images and their digests to stdout.
- Refactored tests to use the `go-cmp` library for more explicit test failures.
- Refactored the `containerfile` package to also parse the last stage of the build. Previously this was unnecessary for Capo, but it is required for usage in upcoming Go reimplementation of Konflux image buildiing.
- Refactored the `containerfile` package to also parse `RUN --mount=type=bind,from=<image>` commands, since those also pull an image during the build.

## Future work
- The current implementation is not currently ready to be used in the Go reimplementation of Konflux image building. Our containerfile parsing implementation rejects containerfiles that use relative paths in COPY commands when the WORKDIR is not explicitly set. This would be fine for contextualization (we would just skip contextualizing) but cannot fail in the build CLI tool. We will need a refactoring so that resolving relative paths happens after the parsing.