### PR TITLE
feat(ISV-7166): add support for chained builder stages

### DIFF
--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -149,14 +149,14 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 	// maps stage alias to root base pullspec (resolved through chain)
 	aliasToBase := make(map[string]string)
 
-	for i, s := range rawStages {
+	for index, s := range rawStages {
 		stageNames = append(stageNames, s.Name)
 
-		isFinal := i == len(rawStages)-1
-		index := i
+		isFinal := index == len(rawStages)-1
+		stageIndex := index
 		if isFinal {
 			s.Name = FinalStage
-			index = -1
+			stageIndex = -1
 		}
 
 		copies, mounts, err := parseStageRefs(s, stageNames)
@@ -164,7 +164,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 			return res, err
 		}
 
-		baseRef := pullspecs[i]
+		baseRef := pullspecs[index]
 		base := baseRef
 		// resolve chained stages: if baseRef is an alias of a previous stage,
 		// use its already-resolved root base pullspec
@@ -177,7 +177,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 			Alias:   s.Name,
 			Base:    base,
 			BaseRef: baseRef,
-			Index:   index,
+			Index:   stageIndex,
 			Copies:  copies,
 			Mounts:  mounts,
 		})

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -81,8 +81,14 @@ const (
 type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final.
 	Alias string
-	// Base image for the stage. Can be a pullspec, "scratch", or "oci-archive".
+	// Base image pullspec for this stage. For chained stages (FROM parent AS child),
+	// this is resolved through the chain to the ultimate builder base image pullspec.
 	Base string
+	// Raw FROM reference as it appears in the Containerfile. Can be a pullspec
+	// or a stage alias. For non-chained stages, BaseRef == Base.
+	BaseRef string
+	// Zero-based index of this builder stage. Final stage has Index -1.
+	Index int
 	// Builder copies in this stage in order (top to bottom in the containerfile).
 	Copies []Copy
 	// Mount references in this stage.
@@ -140,11 +146,17 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 		return nil, err
 	}
 	stageNames := make([]string, 0)
+	// maps stage alias to root base pullspec (resolved through chain)
+	aliasToBase := make(map[string]string)
 
 	for i, s := range rawStages {
 		stageNames = append(stageNames, s.Name)
-		if i == len(rawStages)-1 {
+
+		isFinal := i == len(rawStages)-1
+		index := i
+		if isFinal {
 			s.Name = FinalStage
+			index = -1
 		}
 
 		copies, mounts, err := parseStageRefs(s, stageNames)
@@ -152,11 +164,22 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 			return res, err
 		}
 
+		baseRef := pullspecs[i]
+		base := baseRef
+		// resolve chained stages: if baseRef is an alias of a previous stage,
+		// use its already-resolved root base pullspec
+		if resolvedBase, isChained := aliasToBase[baseRef]; isChained {
+			base = resolvedBase
+		}
+		aliasToBase[s.Name] = base
+
 		res = append(res, Stage{
-			Alias:  s.Name,
-			Base:   pullspecs[i],
-			Copies: copies,
-			Mounts: mounts,
+			Alias:   s.Name,
+			Base:    base,
+			BaseRef: baseRef,
+			Index:   index,
+			Copies:  copies,
+			Mounts:  mounts,
 		})
 	}
 

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -116,20 +116,26 @@ func TestParse(t *testing.T) {
 							FROM scratch`,
 			expected: []Stage{
 				{
-					Alias:  "builder0",
-					Base:   "docker.io/library/fedora",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder0",
+					Base:    "docker.io/library/fedora",
+					BaseRef: "docker.io/library/fedora",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/alpine:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/alpine:latest",
+					BaseRef: "docker.io/library/alpine:latest",
+					Index:   1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: "somethingelse",
-					Base:  "builder1",
+					Alias:   "somethingelse",
+					Base:    "docker.io/library/alpine:latest",
+					BaseRef: "builder1",
+					Index:   2,
 					Copies: []Copy{
 						{
 							From:        "builder0",
@@ -145,7 +151,7 @@ func TestParse(t *testing.T) {
 						},
 					},
 				},
-				{Base: "scratch", Alias: FinalStage, Copies: []Copy{}, Mounts: []Mount{}},
+				{Alias: FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1, Copies: []Copy{}, Mounts: []Mount{}},
 			},
 		},
 		"build target": {
@@ -764,14 +770,57 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		"chained stages resolve base through chain": {
+			containerfile: `FROM docker.io/library/fedora:latest AS parent
+							FROM parent AS child
+							FROM child AS grandchild
+							FROM scratch
+							COPY --from=grandchild /app /app`,
+			expected: []Stage{
+				{
+					Alias:   "parent",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+				},
+				{
+					Alias:   "child",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "parent",
+					Index:   1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+				},
+				{
+					Alias:   "grandchild",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "child",
+					Index:   2,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+				},
+				{
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies: []Copy{
+						{From: "grandchild", Sources: []string{"/app"}, Destination: "/app", Type: CopyTypeBuilder},
+					},
+					Mounts: []Mount{},
+				},
+			},
+		},
 		"run with mount is parsed correctly": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							FROM scratch
 							RUN --mount=type=bind,from=builder,src=/app,dst=/app ls /app
 							RUN --mount=type=cache,from=quay.io/builder,src=/cache,dst=/cache ls /cache`,
 			expected: []Stage{
-				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}, Mounts: []Mount{}},
-				{Alias: FinalStage, Base: "scratch", Copies: []Copy{}, Mounts: []Mount{
+				{Alias: "builder", Base: "quay.io/rhel:9", BaseRef: "quay.io/rhel:9", Index: 0, Copies: []Copy{}, Mounts: []Mount{}},
+				{Alias: FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1, Copies: []Copy{}, Mounts: []Mount{
 					{
 						FromRaw:   "builder",
 						MountType: MountTypeBind,

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -21,14 +21,18 @@ func TestParseBuiltinArgs(t *testing.T) {
 
 	expected := []Stage{
 		{
-			Alias:  "builder",
-			Base:   expectedPullspec,
-			Copies: []Copy{},
-			Mounts: []Mount{},
+			Alias:   "builder",
+			Base:    expectedPullspec,
+			BaseRef: expectedPullspec,
+			Index:   0,
+			Copies:  []Copy{},
+			Mounts:  []Mount{},
 		},
 		{
-			Alias: FinalStage,
-			Base:  "scratch",
+			Alias:   FinalStage,
+			Base:    "scratch",
+			BaseRef: "scratch",
+			Index:   -1,
 			Copies: []Copy{
 				{
 					From:        "builder",
@@ -73,14 +77,18 @@ func TestParse(t *testing.T) {
 			},
 			expected: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/library/alpine:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder",
+					Base:    "docker.io/library/alpine:latest",
+					BaseRef: "docker.io/library/alpine:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "docker.io/library/fedora:latest",
@@ -150,8 +158,10 @@ func TestParse(t *testing.T) {
 			},
 			expected: []Stage{
 				{
-					Alias: FinalStage,
-					Base:  "docker.io/library/fedora:latest",
+					Alias:   FinalStage,
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "docker.io/library/alpine:latest",
@@ -172,20 +182,26 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/helm /usr/bin/helm`,
 			expected: []Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias:  "builder2",
-					Base:   "docker.io/alpine/helm:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -212,14 +228,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/oras /usr/bin/oras`,
 			expected: []Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -231,8 +251,10 @@ func TestParse(t *testing.T) {
 					Mounts: []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -254,14 +276,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder /usr/bin/capo ../..`,
 			expected: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/alpine/helm:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder",
@@ -298,14 +324,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder /usr/bin/mage .`,
 			expected: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/alpine/helm:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder",
@@ -376,14 +406,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/oras /usr/bin/helm /app/`,
 			expected: []Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -395,8 +429,10 @@ func TestParse(t *testing.T) {
 					Mounts: []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -418,14 +454,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /app/ /app/`,
 			expected: []Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -443,8 +483,10 @@ func TestParse(t *testing.T) {
 					Mounts: []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder2",
@@ -463,14 +505,18 @@ func TestParse(t *testing.T) {
 							COPY --from=0 /usr/bin/binary /usr/bin/binary`,
 			expected: []Stage{
 				{
-					Alias:  "0",
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "0",
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "0",
@@ -489,14 +535,18 @@ func TestParse(t *testing.T) {
 							COPY --from=0 /usr/bin/binary /usr/bin/binary`,
 			expected: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder",
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "0",
@@ -514,8 +564,10 @@ func TestParse(t *testing.T) {
 							COPY --from=5 /usr/bin/binary /usr/bin/binary`,
 			expected: []Stage{
 				{
-					Alias: FinalStage,
-					Base:  "quay.io/rhel:9",
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "5",
@@ -533,9 +585,11 @@ func TestParse(t *testing.T) {
 							RUN --mount=type=bind,from=quay.io/tools:1,src=/bin/tool,dst=/tmp/tool /tmp/tool --version`,
 			expected: []Stage{
 				{
-					Alias:  FinalStage,
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
+					Copies:  []Copy{},
 					Mounts: []Mount{
 						{FromRaw: "quay.io/tools:1", Pullspec: "quay.io/tools:1"},
 					},
@@ -548,15 +602,19 @@ func TestParse(t *testing.T) {
 							RUN --mount=type=bind,from=builder,src=/app,dst=/app ls /app`,
 			expected: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder",
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias:  FinalStage,
-					Base:   "scratch",
-					Copies: []Copy{},
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies:  []Copy{},
 					Mounts: []Mount{
 						{FromRaw: "builder"},
 					},
@@ -569,15 +627,19 @@ func TestParse(t *testing.T) {
 							RUN --mount=type=bind,from=0,src=/app,dst=/app ls /app`,
 			expected: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder",
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias:  FinalStage,
-					Base:   "scratch",
-					Copies: []Copy{},
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies:  []Copy{},
 					Mounts: []Mount{
 						{FromRaw: "0"},
 					},
@@ -590,9 +652,9 @@ func TestParse(t *testing.T) {
 							FROM scratch
 							COPY --from=builder /app /app`,
 			expected: []Stage{
-				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}, Mounts: []Mount{}},
-				{Alias: "builder", Base: "quay.io/fedora:42", Copies: []Copy{}, Mounts: []Mount{}},
-				{Alias: FinalStage, Base: "scratch", Copies: []Copy{
+				{Alias: "builder", Base: "quay.io/rhel:9", BaseRef: "quay.io/rhel:9", Index: 0, Copies: []Copy{}, Mounts: []Mount{}},
+				{Alias: "builder", Base: "quay.io/fedora:42", BaseRef: "quay.io/fedora:42", Index: 1, Copies: []Copy{}, Mounts: []Mount{}},
+				{Alias: FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1, Copies: []Copy{
 					{From: "builder", Sources: []string{"/app"}, Destination: "/app", Type: CopyTypeBuilder},
 				}, Mounts: []Mount{}},
 			},
@@ -605,14 +667,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder /foo/baz/../bar /dest3`,
 			expected: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/library/alpine:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder",
+					Base:    "docker.io/library/alpine:latest",
+					BaseRef: "docker.io/library/alpine:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder",
@@ -647,14 +713,18 @@ func TestParse(t *testing.T) {
 							COPY --from=builder2 /usr/bin/helm /usr/bin/helm`,
 			expected: []Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []Copy{},
-					Mounts: []Mount{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []Copy{
 						{
 							From:        "builder1",
@@ -666,8 +736,10 @@ func TestParse(t *testing.T) {
 					Mounts: []Mount{},
 				},
 				{
-					Alias: FinalStage,
-					Base:  "scratch",
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []Copy{
 						{
 							From:        "builder1",

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -36,45 +36,47 @@ var ErrMissingStageLabel = errors.New("[ERR_MISSING_STAGE_LABEL] intermediate im
 // Uses buildah stage labels (io.buildah.stage.name) to identify intermediate
 // image for each stage.
 func (s *Scanner) getContent(
-	pkgSource packageSource,
+	pullspec string,
+	stageAlias string,
+	sources []string,
 	builderContentPath string,
 	intermediateContentPath string,
 ) error {
-	isSpecialBase := storageclient.IsSpecialBase(pkgSource.pullspec)
+	isSpecialBase := storageclient.IsSpecialBase(pullspec)
 	var builderImage *storage.Image
 
 	if !isSpecialBase {
 		// Special bases are not pullable or resolvable with Lookup
-		imgId, err := s.store.Lookup(storageclient.StripTransport(pkgSource.pullspec))
+		imgId, err := s.store.Lookup(storageclient.StripTransport(pullspec))
 		if err != nil {
-			return fmt.Errorf("could not find image %q in buildah storage: %w", pkgSource.pullspec, ErrImageNotFound)
+			return fmt.Errorf("could not find image %q in buildah storage: %w", pullspec, ErrImageNotFound)
 		}
 		builderImage, err = s.store.Image(imgId)
 		if err != nil {
-			return fmt.Errorf("could not find image %q in buildah storage: %w", pkgSource.pullspec, ErrImageNotFound)
+			return fmt.Errorf("could not find image %q in buildah storage: %w", pullspec, ErrImageNotFound)
 		}
 	}
 
 	// Special bases will have builderImage set as nil
 	intermediate, err := s.getIntermediateContent(
 		builderImage,
-		pkgSource.alias,
-		pkgSource.sources,
+		stageAlias,
+		sources,
 		intermediateContentPath,
 	)
 
 	if err != nil {
 		return err
 	}
-	s.logContent("intermediate", intermediate, pkgSource.pullspec)
+	s.logContent("intermediate", intermediate, pullspec)
 
 	if !isSpecialBase {
 		// Only standard bases have builder content. All content in special bases is treated as intermediate.
-		builderContent, err := s.getImageContent(builderImage, pkgSource.sources, builderContentPath)
+		builderContent, err := s.getImageContent(builderImage, sources, builderContentPath)
 		if err != nil {
 			return err
 		}
-		s.logContent("builder", builderContent, pkgSource.pullspec)
+		s.logContent("builder", builderContent, pullspec)
 	}
 
 	return nil
@@ -86,6 +88,45 @@ func (s *Scanner) logContent(kind string, content []string, pullspec string) {
 	} else {
 		s.logger.Debug("included content", "kind", kind, "content", content, "pullspec", pullspec)
 	}
+}
+
+// getDescendantContent extracts intermediate content for a chained stage (node)
+// by diffing its intermediate image against the provided diff base image.
+// Returns the node's intermediate image and the list of extracted paths.
+// The returned image is passed as diff base to further descendants in the chain.
+// If the node has no intermediate image (empty stage), returns diffBase unchanged
+// so it propagates through to the next descendant.
+func (s *Scanner) getDescendantContent(
+	stageAlias string,
+	diffBase *storage.Image,
+	sources []string,
+	contentPath string,
+) (*storage.Image, []string, error) {
+	intermediateImage, found, err := s.findIntermediateImage(stageAlias)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: failed to find intermediate image for %q: %w", ErrStorage, stageAlias, err)
+	}
+	if !found {
+		// no intermediate image found for node — pass diffBase through unchanged
+		return diffBase, nil, nil
+	}
+
+	diffBaseLayer, err := s.store.Layer(diffBase.TopLayer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: failed to get diff base layer: %w", ErrStorage, err)
+	}
+
+	interLayer, err := s.store.Layer(intermediateImage.TopLayer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: failed to get intermediate layer: %w", ErrStorage, err)
+	}
+
+	included, err := s.saveDiff(contentPath, interLayer.ID, diffBaseLayer.ID, sources)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return intermediateImage, included, nil
 }
 
 // IsPathUnderPattern reports whether path matches pattern exactly (via filepath.Match)

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -105,7 +105,7 @@ func (s *Scanner) getDescendantContent(
 		return nil, nil, fmt.Errorf("%w: failed to find intermediate image for %q: %w", ErrStorage, stageAlias, err)
 	}
 	if !found {
-		// no intermediate image found for node — pass diffBase through unchanged
+		// no intermediate image found for node - pass diffBase through unchanged
 		s.logger.Debug("no intermediate image found for chained stage, skipping", "stage", stageAlias)
 		return diffBase, nil, nil
 	}

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -29,12 +29,10 @@ var ErrStorage = errors.New("[ERR_STORAGE] container storage error")
 var ErrUnsupportedBuildahVersion = errors.New("[ERR_UNSUPPORTED_BUILDAH_VERSION] unsupported buildah version")
 var ErrMissingStageLabel = errors.New("[ERR_MISSING_STAGE_LABEL] intermediate image is missing stage label")
 
-// getContent uses the container store to extract partial content from the build
-// for the specified package source. Extracts both builder base content and
-// intermediate content (created during the build) for later syft scanning.
-//
-// Uses buildah stage labels (io.buildah.stage.name) to identify intermediate
-// image for each stage.
+// getContent extracts builder base content and intermediate content for the
+// specified stage from buildah storage for later syft scanning.
+// Uses buildah stage labels (io.buildah.stage.name) to identify the
+// intermediate image for the given stage alias.
 func (s *Scanner) getContent(
 	pullspec string,
 	stageAlias string,
@@ -108,6 +106,7 @@ func (s *Scanner) getDescendantContent(
 	}
 	if !found {
 		// no intermediate image found for node — pass diffBase through unchanged
+		s.logger.Debug("no intermediate image found for chained stage, skipping", "stage", stageAlias)
 		return diffBase, nil, nil
 	}
 

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -88,6 +88,32 @@ func (s *Scanner) logContent(kind string, content []string, pullspec string) {
 	}
 }
 
+// getExternalContent extracts content from an external image (COPY --from=image:tag).
+// External images have no intermediate layer — only the image content is extracted.
+func (s *Scanner) getExternalContent(
+	pullspec string,
+	sources []string,
+	contentPath string,
+) error {
+	imgID, err := s.store.Lookup(storageclient.StripTransport(pullspec))
+	if err != nil {
+		return fmt.Errorf("could not find external image %q in buildah storage: %w", pullspec, ErrImageNotFound)
+	}
+
+	img, err := s.store.Image(imgID)
+	if err != nil {
+		return fmt.Errorf("could not find external image %q in buildah storage: %w", pullspec, ErrImageNotFound)
+	}
+
+	content, err := s.getImageContent(img, sources, contentPath)
+	if err != nil {
+		return err
+	}
+
+	s.logContent("external", content, pullspec)
+	return nil
+}
+
 // getDescendantContent extracts intermediate content for a chained stage (node)
 // by diffing its intermediate image against the provided diff base image.
 // Returns the node's intermediate image and the list of extracted paths.

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1235,7 +1235,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages / external content] Content traced through intermediate builder via COPY chain with external image": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported, bug with external image in builder stage unresolved",
 			TestImage: BuildDefinition{
 				Tag: "test-chain-with-external",
 				ContainerfileContent: `FROM localhost/base-img:latest AS builder
@@ -1285,13 +1284,11 @@ func TestIntegration(t *testing.T) {
 						PackageURL: "pkg:golang/golang.org/x/text@v0.18.0",
 						OriginType: "external",
 						Pullspec:   "localhost/in-chain-ext@sha256:dummy",
-						StageAlias: "builder",
 					},
 				},
 			},
 		},
 		"[External content] External COPY in final stage": {
-			SkipTestReason: "[Priority: medium] origin_type 'external' not yet implemented - capo reports external content as 'builder'. Works otherwise.",
 			TestImage: BuildDefinition{
 				Tag: "test-external-copy-final",
 				ContainerfileContent: `FROM localhost/builder-base:latest AS builder
@@ -1348,7 +1345,6 @@ func TestIntegration(t *testing.T) {
 		// modeled as DESCENDANT_OF builder base image — external image content in a
 		// builder stage has no such relationship to the builder base.
 		"[External content] External COPY in builder stage - content traced through builder to final": {
-			SkipTestReason: "[Priority: high] bug: traceSource panic on nil stage from external COPY --from in builder",
 			TestImage: BuildDefinition{
 				Tag: "test-external-copy-in-builder",
 				ContainerfileContent: `FROM localhost/builder-base:latest AS builder

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -898,8 +898,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages] Grandparent, parent and child builder cascade with intermediate content": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported",
-			TestImage: BuildDefinition{
+						TestImage: BuildDefinition{
 				Tag: "test-chained-stages-cascade",
 				ContainerfileContent: `FROM localhost/builder-sync:latest AS grandparent
 										COPY go_uuid.mod /opt/app2/go.mod
@@ -956,8 +955,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages] Empty child chained stage (no build instructions)": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported",
-			TestImage: BuildDefinition{
+						TestImage: BuildDefinition{
 				Tag: "test-empty-chained-stage",
 				ContainerfileContent: `FROM localhost/capo-builder/go_builder:latest AS parent-stage
 										COPY go_uuid.mod /opt/app2/go.mod
@@ -996,8 +994,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages] Multiple empty chained stages with intermediate only in last stage": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported",
-			TestImage: BuildDefinition{
+						TestImage: BuildDefinition{
 				Tag: "test-empty-chain-cascade",
 				ContainerfileContent: `FROM localhost/builder-base:latest AS first
 
@@ -1038,8 +1035,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages] Complex cascade: non-empty, empty, non-empty, empty, non-empty": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported",
-			TestImage: BuildDefinition{
+						TestImage: BuildDefinition{
 				Tag: "test-complex-cascade",
 				ContainerfileContent: `FROM localhost/builder-base:latest AS stage1
 										COPY go_uuid.mod /opt/app1/go.mod
@@ -1100,8 +1096,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages] Empty chained stages copying only builder base content": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported",
-			TestImage: BuildDefinition{
+						TestImage: BuildDefinition{
 				Tag: "test-empty-chain-builder-only",
 				ContainerfileContent: `FROM localhost/builder-with-content:latest AS alias
 
@@ -1132,8 +1127,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages] Diamond dependency - two branches from same parent": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported",
-			TestImage: BuildDefinition{
+						TestImage: BuildDefinition{
 				Tag: "test-diamond-dependency",
 				ContainerfileContent: `FROM localhost/diamond-base:latest AS shared
 										COPY go_uuid.mod /shared/go.mod
@@ -1169,7 +1163,7 @@ func TestIntegration(t *testing.T) {
 						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
 						OriginType: "builder",
 						Pullspec:   "localhost/diamond-base@sha256:dummy",
-						StageAlias: "right",
+						StageAlias: "shared",
 					},
 					{
 						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
@@ -1197,26 +1191,23 @@ func TestIntegration(t *testing.T) {
 		// alias over registry image — "FROM alpine" references the stage, not
 		// docker.io/library/alpine:latest. This is a chained stage scenario.
 		"[Chained stages] Stage alias with same name as image": {
-			SkipTestReason: "[Priority: low] chained stages not yet supported — stage alias takes precedence over image name (verified with buildah and Docker)",
 			TestImage: BuildDefinition{
 				Tag: "test-alias-matches-image",
 				ContainerfileContent: `FROM localhost/builderwithbadalias:latest AS alpine
-										COPY go_uuid.mod /content/app2/go.mod
+										COPY go_uuid.mod /opt/app2/go.mod
 
 										FROM alpine AS stage2
-										COPY go_exp.mod /content/app3/go.mod
+										COPY go_exp.mod /opt/app3/go.mod
 
 										FROM scratch
-										COPY --from=alpine /base /base
-										COPY --from=alpine /content /content/stage1
-										COPY --from=stage2 / /content/all`,
+										COPY --from=stage2 /opt/ /opt/`,
 				ContextDirectory: "../testdata/image_content",
 			},
 			BuilderImages: []BuildDefinition{
 				{
 					Tag: "builderwithbadalias",
 					ContainerfileContent: `FROM scratch
-											COPY go_syft.mod /content/app1/go.mod`,
+											COPY go_syft.mod /opt/app1/go.mod`,
 					ContextDirectory: "../testdata/image_content",
 				},
 			},
@@ -1225,19 +1216,19 @@ func TestIntegration(t *testing.T) {
 					{
 						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
 						OriginType: "builder",
-						Pullspec:   "localhost/alpine@sha256:dummy",
+						Pullspec:   "localhost/builderwithbadalias@sha256:dummy",
 						StageAlias: "alpine",
 					},
 					{
 						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
 						OriginType: "intermediate",
-						Pullspec:   "localhost/alpine@sha256:dummy",
+						Pullspec:   "localhost/builderwithbadalias@sha256:dummy",
 						StageAlias: "alpine",
 					},
 					{
 						PackageURL: "pkg:golang/golang.org/x/exp@v0.0.0-20240808152545-0cdaa3abc0fa",
 						OriginType: "intermediate",
-						Pullspec:   "localhost/alpine@sha256:dummy",
+						Pullspec:   "localhost/builderwithbadalias@sha256:dummy",
 						StageAlias: "stage2",
 					},
 				},

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -77,7 +77,7 @@ type PackageMetadataItem struct {
 	// found multiple times as a dependency of different packages.
 	DependencyOfPURL string `json:"dependency_of_purl,omitempty"`
 
-	// Type of origin of this package, can be "builder" or "intermediate".
+	// Type of origin of this package, can be "builder", "intermediate" or "external".
 	OriginType string `json:"origin_type"`
 
 	// Pullspec of the image with digest which is this package's origin.
@@ -209,7 +209,7 @@ func (s *Scanner) Scan(
 	}
 
 	for _, ext := range externals {
-		extPkgItems, err := s.scanSource(ext.pullspec, "", ext.digestBase, ext.sources)
+		extPkgItems, err := s.scanExternalSource(ext)
 		if err != nil {
 			return PackageMetadata{}, fmt.Errorf("failed to scan external source %+v: %w", ext, err)
 		}
@@ -335,7 +335,7 @@ func getPackageSources(
 			// Multiple copies from same external image (multiple COPY instructions referencing same image,
 			// not sources) are grouped under same pullspec.
 			if idx, isBuilder := aliasToIndex[cp.From]; isBuilder {
-				traceSource(source, idx, builderStageAcc, indexToStage, aliasToIndex, baseToWorkdir)
+				traceSource(source, idx, builderStageAcc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
 			} else {
 				externalAcc[cp.From] = append(externalAcc[cp.From], source)
 			}
@@ -440,6 +440,7 @@ func buildSourceTree(
 
 // traceSource recursively traces a source path through builder stage COPY
 // commands to find its true origin. Maps stage indices to source paths in acc.
+// External COPY --from references in builder stages are collected in externalAcc.
 // baseToWorkdir is a mapping of bases of stages in the containerfile and their
 // respective initial working directories.
 func traceSource(
@@ -448,6 +449,7 @@ func traceSource(
 	acc map[int][]string,
 	indexToStage map[int]*containerfile.Stage,
 	aliasToIndex map[string]int,
+	externalAcc map[string][]string,
 	baseToWorkdir map[string]string,
 ) {
 	currStage := indexToStage[stageIndex]
@@ -477,7 +479,13 @@ func traceSource(
 				coversMultipleFiles = true
 			}
 			for _, s := range cp.Sources {
-				traceSource(s, aliasToIndex[cp.From], acc, indexToStage, aliasToIndex, baseToWorkdir)
+				if nextIdx, ok := aliasToIndex[cp.From]; ok {
+					// builder stage - continue tracing
+					traceSource(s, nextIdx, acc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
+				} else {
+					// external image - add as external source
+					externalAcc[cp.From] = append(externalAcc[cp.From], s)
+				}
 			}
 		}
 	}
@@ -492,7 +500,7 @@ func traceSource(
 
 	// chained stage — propagate source to parent for builder content scanning
 	if parentIdx, ok := aliasToIndex[currStage.BaseRef]; ok {
-		traceSource(source, parentIdx, acc, indexToStage, aliasToIndex, baseToWorkdir)
+		traceSource(source, parentIdx, acc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
 	}
 }
 
@@ -636,6 +644,42 @@ func (s *Scanner) scanDescendants(
 	return res, nil
 }
 
+// scanExternalSource scans content from an external image (COPY --from=image:tag).
+// External images have no intermediate layer - only the image content is extracted
+// and reported with origin_type "external".
+func (s *Scanner) scanExternalSource(
+	ext ExternalPackageSource,
+) (_ []PackageMetadataItem, err error) {
+	contentPath, err := os.MkdirTemp("", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w: %w", err, ErrIO)
+	}
+
+	debugMode := os.Getenv("CAPO_DEBUG") != ""
+	if debugMode {
+		s.logger.Debug("external content path", "pullspec", ext.pullspec, "path", contentPath)
+	} else {
+		defer func() {
+			removeErr := os.RemoveAll(contentPath)
+			if err == nil {
+				err = removeErr
+			}
+		}()
+	}
+
+	err = s.getExternalContent(ext.pullspec, ext.sources, contentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs, err := sbom.SyftScan(contentPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan external content: %w: %w", err, ErrSBOMScan)
+	}
+
+	return getPackageMetadata("", ext.digestBase, "external", pkgs, nil), nil
+}
+
 // scanSource extracts content for a stage from buildah storage, scans it
 // with syft, and returns package metadata items.
 func (s *Scanner) scanSource(
@@ -690,7 +734,7 @@ func (s *Scanner) scanSource(
 	}
 
 	return getPackageMetadata(
-		stageAlias, digestBase, builderPkgs, intermediatePkgs,
+		stageAlias, digestBase, "builder", builderPkgs, intermediatePkgs,
 	), nil
 }
 
@@ -699,6 +743,7 @@ func (s *Scanner) scanSource(
 func getPackageMetadata(
 	stageAlias string,
 	digestBase string,
+	builderOriginType string,
 	builderPkgs []sbom.SyftPackage,
 	intermediatePkgs []sbom.SyftPackage,
 ) []PackageMetadataItem {
@@ -711,7 +756,7 @@ func getPackageMetadata(
 			PackageURL:       bpkg.PURL,
 			DependencyOfPURL: bpkg.DependencyOfPURL,
 			Checksums:        bpkg.Checksums,
-			OriginType:       "builder",
+			OriginType:       builderOriginType,
 		})
 	}
 

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -228,10 +228,9 @@ func getImageDigests(
 	res := make(map[string]digest.Digest)
 
 	for _, stage := range stages[:len(stages)-1] {
-		// chained stages share the same base as their root - already resolved
-		if stage.Base != stage.BaseRef {
-			continue
-		}
+		// This deduplication check covers both duplicate pullspecs across
+		// the containerfile and implicitly skips chained stages (their root
+		// stage already resolved the shared base pullspec).
 		if _, ok := res[stage.Base]; !ok {
 			if storageclient.IsSpecialBase(stage.Base) {
 				continue

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -19,19 +19,45 @@ import (
 	"go.podman.io/storage/pkg/reexec"
 )
 
-type packageSource struct {
-	// Stage alias of this stage or empty string
-	// if this is only an external stage, i.e. there are COPY commands
-	// only in the form of 'COPY --from=image:tag ... ...'.
+// BuilderPackageSourceRoot represents a non-chained builder stage or the root of a
+// chain of stages that share the same external base image. Chained stages
+// (FROM parent-alias AS child-alias) are attached as descendants.
+type BuilderPackageSourceRoot struct {
+	// Index of this builder stage.
+	index int
+	// Stage alias.
 	alias string
-
-	// Pullspec of this stage as it appeared in the containerfile.
+	// Base image pullspec as it appeared in the containerfile.
 	pullspec string
-
-	// Pullspec of the base of this stage with digest instead of tag.
+	// Base image pullspec with resolved digest.
 	digestBase string
+	// Paths to content that should be syft-scanned.
+	sources []string
+	// Chained stages that use this stage (or its descendants) as base.
+	descendants []*BuilderPackageSourceNode
+}
 
-	// Slice of paths to content in the layer/image which should be syft-scanned
+// BuilderPackageSourceNode represents a chained builder stage - a descendant of a
+// BuilderPackageSourceRoot or another BuilderPackageSourceNode.
+type BuilderPackageSourceNode struct {
+	// Index of this builder stage.
+	index int
+	// Stage alias.
+	alias string
+	// Paths to content that should be syft-scanned.
+	sources []string
+	// Further chained stages.
+	descendants []*BuilderPackageSourceNode
+}
+
+// ExternalPackageSource is used for external image sources (COPY --from=image:tag)
+// that are not builder stages.
+type ExternalPackageSource struct {
+	// Base image pullspec as it appeared in the COPY --from=pullspec instruction.
+	pullspec string
+	// Base image pullspec with resolved digest.
+	digestBase string
+	// Paths to content that should be syft-scanned.
 	sources []string
 }
 
@@ -169,30 +195,43 @@ func (s *Scanner) Scan(
 		return PackageMetadata{}, err
 	}
 
-	pkgSources, err := getPackageSources(s.sclient, stages, digests)
+	roots, externals, err := getPackageSources(s.sclient, stages, digests)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
-	for _, pkgSource := range pkgSources {
-		stagePkgItems, err := s.scanSource(pkgSource)
-		if err != nil {
-			return PackageMetadata{}, fmt.Errorf("failed to scan source for stage %q: %w: %w", pkgSource.alias, err, ErrSBOMScan)
-		}
 
-		res.Packages = append(res.Packages, stagePkgItems...)
+	for _, root := range roots {
+		rootPkgItems, err := s.scanBuilderStageTree(root)
+		if err != nil {
+			return PackageMetadata{}, fmt.Errorf("failed to scan tree for stage %q: %w", root.alias, err)
+		}
+		res.Packages = append(res.Packages, rootPkgItems...)
+	}
+
+	for _, ext := range externals {
+		extPkgItems, err := s.scanSource(ext.pullspec, "", ext.digestBase, ext.sources)
+		if err != nil {
+			return PackageMetadata{}, fmt.Errorf("failed to scan external source %+v: %w", ext, err)
+		}
+		res.Packages = append(res.Packages, extPkgItems...)
 	}
 
 	return res, nil
 }
 
 // Map all pullspecs found in the containerfile to their current digests in
-// container storage.
+// container storage. Chained stages are skipped (their Base is already the
+// root pullspec, resolved by the parser).
 func getImageDigests(
 	storageClient storageclient.Client, stages []containerfile.Stage,
 ) (map[string]digest.Digest, error) {
 	res := make(map[string]digest.Digest)
 
 	for _, stage := range stages[:len(stages)-1] {
+		// chained stages share the same base as their root - already resolved
+		if stage.Base != stage.BaseRef {
+			continue
+		}
 		if _, ok := res[stage.Base]; !ok {
 			if storageclient.IsSpecialBase(stage.Base) {
 				continue
@@ -244,27 +283,27 @@ func attachDigest(pullspec string, dig digest.Digest) (string, error) {
 	return final.String(), nil
 }
 
-// getPackageSources uses the passed containerfile stages and returns a slice
-// of packageSource structs, specifying which COPY-ied content originates from
-// which builder stage. Uses the passed storageclient.Client to get
-// OCIImageConfigs of base images to get their default workdirs for relative
-// path resolution in copy destinations.
+// getPackageSources traces content origins from the final stage through builder
+// stages and returns a tree of BuilderPackageSourceRoot (one per non-chained builder
+// stage) with chained stages attached as BuilderPackageSourceNode descendants.
+// External COPY --from sources are returned separately.
+// Uses the passed storageclient.Client to get OCIImageConfigs of base images
+// to get their default workdirs for relative path resolution in copy destinations.
 func getPackageSources(
 	storageClient storageclient.Client,
 	stages []containerfile.Stage,
 	digests map[string]digest.Digest,
-) ([]packageSource, error) {
-	res := make([]packageSource, 0)
-	aliasToStage := make(map[string]*containerfile.Stage)
-
-	// use index iteration to get consistent references to stages
-	// since we use the references as map keys
+) ([]BuilderPackageSourceRoot, []ExternalPackageSource, error) {
+	// lookup maps for traceSource
+	aliasToIndex := make(map[string]int)
+	indexToStage := make(map[int]*containerfile.Stage)
 	for i := range stages[:len(stages)-1] {
 		st := &stages[i]
-		aliasToStage[st.Alias] = st
+		aliasToIndex[st.Alias] = st.Index
+		indexToStage[st.Index] = st
 		// also map numeric index so COPY --from=<index> resolves
 		// correctly even when stage aliases are present
-		aliasToStage[strconv.Itoa(i)] = st
+		aliasToIndex[strconv.Itoa(i)] = st.Index
 	}
 
 	// mapping of bases used in the containerfile to their initial working
@@ -277,7 +316,7 @@ func getPackageSources(
 
 		cfg, err := storageClient.GetImageConfig(s.Base)
 		if err != nil {
-			return []packageSource{}, fmt.Errorf("failed to get OCI image config for %q: %w", s.Base, ErrOCIConfig)
+			return nil, nil, fmt.Errorf("failed to get OCI image config for %q: %w", s.Base, ErrOCIConfig)
 		}
 
 		baseToWorkdir[s.Base] = cfg.Config.Workdir
@@ -285,96 +324,134 @@ func getPackageSources(
 
 	// The following code block reads all the builder COPY-ies in the final stage
 	// and recursively traces their content to their respective origins in previous stages.
-	// Builds a map between references to containerfile stages and the sources used in the COPY.
+	// Builds a map between stage indices and the source paths that originated in them.
 	final := &stages[len(stages)-1]
-	stageToSources := make(map[*containerfile.Stage][]string)
+	builderStageAcc := make(map[int][]string)
+	externalAcc := make(map[string][]string)
 
 	for _, cp := range final.Copies {
 		for _, source := range cp.Sources {
 			// the copy is builder type only if there's no builder stage with alias equal to the cp.from
 			// otherwise the cp.from is a pullspec and it is an external copy
-			if _, isBuilder := aliasToStage[cp.From]; isBuilder {
-				traceSource(source, aliasToStage[cp.From], stageToSources, aliasToStage, baseToWorkdir)
+			// Multiple copies from same external image (multiple COPY instructions referencing same image,
+			// not sources) are grouped under same pullspec.
+			if idx, isBuilder := aliasToIndex[cp.From]; isBuilder {
+				traceSource(source, idx, builderStageAcc, indexToStage, aliasToIndex, baseToWorkdir)
 			} else {
-				external := containerfile.Stage{
-					Alias:  "",
-					Base:   cp.From,
-					Copies: []containerfile.Copy{},
-				}
-
-				stageToSources[&external] = append(stageToSources[&external], source)
+				externalAcc[cp.From] = append(externalAcc[cp.From], source)
 			}
 		}
 	}
 
-	var err error
-	pullspec := ""
-
-	// construct builder package sources
-	for i := range stages[:len(stages)-1] {
-		stage := &stages[i]
-
-		dig, exists := digests[stage.Base]
-		if exists {
-			pullspec, err = attachDigest(storageclient.StripTransport(stage.Base), dig)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			pullspec = stage.Base
-		}
-
-		res = append(res, packageSource{
-			alias:      stage.Alias,
-			pullspec:   stage.Base,
-			digestBase: pullspec,
-			sources:    stageToSources[stage],
-		})
-
-		// the processed stage must be deleted from stageToSources so it only
-		// contains "external" stages after builder stages are constructed.
-		// These are then processed in the next code block below.
-		delete(stageToSources, stage)
+	roots, err := buildSourceTree(stages, builderStageAcc, aliasToIndex, digests)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// construct external package sources
-	for stage, sources := range stageToSources {
-		dig, exists := digests[stage.Base]
+	externals := make([]ExternalPackageSource, 0)
+	for pullspec, sources := range externalAcc {
+		dig, exists := digests[pullspec]
+		var digestBase string
 		if exists {
-			pullspec, err = attachDigest(storageclient.StripTransport(stage.Base), dig)
+			var err error
+			digestBase, err = attachDigest(storageclient.StripTransport(pullspec), dig)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		} else {
-			pullspec = stage.Base
+			digestBase = pullspec
 		}
 
-		res = append(res, packageSource{
-			alias:      stage.Alias,
-			pullspec:   stage.Base,
-			digestBase: pullspec,
+		externals = append(externals, ExternalPackageSource{
+			pullspec:   pullspec,
+			digestBase: digestBase,
 			sources:    sources,
 		})
 	}
 
-	return res, nil
+	return roots, externals, nil
 }
 
-// traceSource takes a source path and the stage it was found in and recursively
-// traces its origin up the builder stages. Once the true origin of the source
-// path is found it modifies the passed accumulator so that pointers to stages map
-// to the source paths that originated in them.
-// aliasToStage is a mapping of stage aliases to stage pointers to use for lookups
-// when resolving COPY commands.
+// buildSourceTree constructs a tree of BuilderPackageSourceRoot (non-chained stages)
+// with BuilderPackageSourceNode descendants (chained stages) from the traced sources.
+func buildSourceTree(
+	stages []containerfile.Stage,
+	builderStageAcc map[int][]string,
+	aliasToIndex map[string]int,
+	digests map[string]digest.Digest,
+) ([]BuilderPackageSourceRoot, error) {
+	rootByIndex := make(map[int]*BuilderPackageSourceRoot)
+	nodeByIndex := make(map[int]*BuilderPackageSourceNode)
+
+	for _, builderStage := range stages[:len(stages)-1] {
+		isChained := builderStage.Base != builderStage.BaseRef
+		sources := builderStageAcc[builderStage.Index]
+
+		if !isChained {
+			dig, exists := digests[builderStage.Base]
+			var digestBase string
+			if exists {
+				var err error
+				digestBase, err = attachDigest(storageclient.StripTransport(builderStage.Base), dig)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				digestBase = builderStage.Base
+			}
+
+			root := &BuilderPackageSourceRoot{
+				index:      builderStage.Index,
+				alias:      builderStage.Alias,
+				pullspec:   builderStage.Base,
+				digestBase: digestBase,
+				sources:    sources,
+			}
+			rootByIndex[builderStage.Index] = root
+		} else {
+			node := &BuilderPackageSourceNode{
+				index:   builderStage.Index,
+				alias:   builderStage.Alias,
+				sources: sources,
+			}
+			nodeByIndex[builderStage.Index] = node
+
+			// attach to parent — parent can be a root or another node
+			parentIdx := aliasToIndex[builderStage.BaseRef]
+			if parentRoot, ok := rootByIndex[parentIdx]; ok {
+				parentRoot.descendants = append(parentRoot.descendants, node)
+			} else if parentNode, ok := nodeByIndex[parentIdx]; ok {
+				parentNode.descendants = append(parentNode.descendants, node)
+			}
+		}
+	}
+
+	// collect roots in stage order after building the tree (rootByIndex is a map
+	// which does not guarantee iteration order)
+	roots := make([]BuilderPackageSourceRoot, 0, len(rootByIndex))
+	for _, stage := range stages[:len(stages)-1] {
+		if root, ok := rootByIndex[stage.Index]; ok {
+			roots = append(roots, *root)
+		}
+	}
+
+	return roots, nil
+}
+
+// traceSource recursively traces a source path through builder stage COPY
+// commands to find its true origin. Maps stage indices to source paths in acc.
 // baseToWorkdir is a mapping of bases of stages in the containerfile and their
 // respective initial working directories.
 func traceSource(
 	source string,
-	currStage *containerfile.Stage,
-	acc map[*containerfile.Stage][]string,
-	aliasToStage map[string]*containerfile.Stage,
+	stageIndex int,
+	acc map[int][]string,
+	indexToStage map[int]*containerfile.Stage,
+	aliasToIndex map[string]int,
 	baseToWorkdir map[string]string,
 ) {
+	currStage := indexToStage[stageIndex]
 	coversMultipleFiles := strings.HasSuffix(source, "/") || strings.ContainsAny(source, "*?[]")
 
 	baseWorkdir, ok := baseToWorkdir[currStage.Base]
@@ -401,7 +478,7 @@ func traceSource(
 				coversMultipleFiles = true
 			}
 			for _, s := range cp.Sources {
-				traceSource(s, aliasToStage[cp.From], acc, aliasToStage, baseToWorkdir)
+				traceSource(s, aliasToIndex[cp.From], acc, indexToStage, aliasToIndex, baseToWorkdir)
 			}
 		}
 	}
@@ -411,7 +488,12 @@ func traceSource(
 	// some ancestors. The source could contain mixed content - some from this
 	// stage, some copied from previous stages.
 	if coversMultipleFiles || !foundAncestor {
-		acc[currStage] = append(acc[currStage], source)
+		acc[stageIndex] = append(acc[stageIndex], source)
+	}
+
+	// chained stage — propagate source to parent for builder content scanning
+	if parentIdx, ok := aliasToIndex[currStage.BaseRef]; ok {
+		traceSource(source, parentIdx, acc, indexToStage, aliasToIndex, baseToWorkdir)
 	}
 }
 
@@ -440,11 +522,128 @@ func resolveRelativeDestination(cp containerfile.Copy, baseWorkdir string) strin
 	return filepath.Join(baseWorkdir, cp.Workdir, cp.Destination)
 }
 
-// scanSource uses the passed initialized storage.Store struct to syft scan content
-// from the passed packageSource. Returns a slice of PackageMetadataItem structs specifying
-// origins of packages.
+// scanBuilderStageTree scans a BuilderPackageSourceRoot and all its descendants. For the root,
+// both builder base content and intermediate content are extracted. For
+// descendants, only intermediate content is extracted (diffed against parent's
+// intermediate layer, or builder base if parent has no intermediate).
+func (s *Scanner) scanBuilderStageTree(
+	root BuilderPackageSourceRoot,
+) ([]PackageMetadataItem, error) {
+	res := make([]PackageMetadataItem, 0)
+
+	// root scan
+	rootItems, err := s.scanSource(root.pullspec, root.alias, root.digestBase, root.sources)
+	if err != nil {
+		return nil, err
+	}
+	res = append(res, rootItems...)
+
+	// root's chain descendants scan
+	if len(root.descendants) > 0 {
+		// Resolve the initial diff base for descendants. Descendants diff their
+		// intermediate image against the nearest ancestor with an intermediate.
+		// If nearest ancestor has an intermediate, use it; otherwise fall back
+		// to its builder base image.
+		imgId, err := s.store.Lookup(storageclient.StripTransport(root.pullspec))
+		if err != nil {
+			return nil, fmt.Errorf("could not find image %q in buildah storage: %w", root.pullspec, ErrImageNotFound)
+		}
+		builderBaseImage, err := s.store.Image(imgId)
+		if err != nil {
+			return nil, fmt.Errorf("could not find image %q in buildah storage: %w", root.pullspec, ErrImageNotFound)
+		}
+
+		// root's intermediate image — use as initial diff base if it exists
+		rootDiffBase := builderBaseImage
+		rootIntermediate, found, _ := s.findIntermediateImage(root.alias)
+		if found {
+			rootDiffBase = rootIntermediate
+		}
+
+		// scan direct chained children; scanDescendants recurses into their subtrees.
+		// A root can have multiple direct descendants, e.g.:
+		//   FROM fedora AS root
+		//   FROM root AS left  - descendant1
+		//   FROM root AS right - descendant2
+		for _, desc := range root.descendants {
+			descItems, err := s.scanDescendants(desc, rootDiffBase, root.digestBase)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, descItems...)
+		}
+	}
+
+	return res, nil
+}
+
+// scanDescendants recursively scans chained stage descendants, extracting
+// only intermediate content (diffed against diffBase - the nearest ancestor's
+// intermediate image or the builder base image).
+func (s *Scanner) scanDescendants(
+	node *BuilderPackageSourceNode,
+	diffBase *storage.Image,
+	rootDigestBase string,
+) ([]PackageMetadataItem, error) {
+	res := make([]PackageMetadataItem, 0)
+
+	intermediateContentPath, err := os.MkdirTemp("", "")
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to create temp directory: %w", ErrIO, err)
+	}
+	defer func() { _ = os.RemoveAll(intermediateContentPath) }()
+
+	// getDescendantContent returns the intermediate image for this node
+	// (or diffBase unchanged if node has no intermediate = empty stage)
+	nextDiffBase, intermediate, err := s.getDescendantContent(
+		node.alias, diffBase, node.sources, intermediateContentPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(intermediate) > 0 {
+		s.logContent("intermediate (chained)", intermediate, node.alias)
+
+		intermediatePkgs, err := sbom.SyftScan(intermediateContentPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan intermediate content for %q: %w", node.alias, err)
+		}
+
+		for _, ipkg := range intermediatePkgs {
+			res = append(res, PackageMetadataItem{
+				Pullspec:         rootDigestBase,
+				StageAlias:       node.alias,
+				PackageURL:       ipkg.PURL,
+				DependencyOfPURL: ipkg.DependencyOfPURL,
+				Checksums:        ipkg.Checksums,
+				OriginType:       "intermediate",
+			})
+		}
+	}
+
+	// recurse into further chained stages, e.g.:
+	//   FROM root AS left    ← current node
+	//   FROM left AS child1
+	//   FROM left AS child2
+	for _, child := range node.descendants {
+		childItems, err := s.scanDescendants(child, nextDiffBase, rootDigestBase)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, childItems...)
+	}
+
+	return res, nil
+}
+
+// scanSource extracts content for a stage from buildah storage, scans it
+// with syft, and returns package metadata items.
 func (s *Scanner) scanSource(
-	pkgSource packageSource,
+	pullspec string,
+	stageAlias string,
+	digestBase string,
+	sources []string,
 ) (_ []PackageMetadataItem, err error) {
 	// builder content is content that is present in a builder stage base image
 	builderContentPath, err := os.MkdirTemp("", "")
@@ -462,8 +661,8 @@ func (s *Scanner) scanSource(
 	// and don't remove the temporary directories
 	debugMode := os.Getenv("CAPO_DEBUG") != ""
 	if debugMode {
-		s.logger.Debug("builder content path", "pullspec", pkgSource.pullspec, "path", builderContentPath)
-		s.logger.Debug("intermediate content path", "pullspec", pkgSource.pullspec, "path", intermediateContentPath)
+		s.logger.Debug("builder content path", "pullspec", pullspec, "path", builderContentPath)
+		s.logger.Debug("intermediate content path", "pullspec", pullspec, "path", intermediateContentPath)
 	} else {
 		defer func() {
 			removeErr := errors.Join(
@@ -476,7 +675,7 @@ func (s *Scanner) scanSource(
 		}()
 	}
 
-	err = s.getContent(pkgSource, builderContentPath, intermediateContentPath)
+	err = s.getContent(pullspec, stageAlias, sources, builderContentPath, intermediateContentPath)
 	if err != nil {
 		return nil, err
 	}
@@ -492,14 +691,15 @@ func (s *Scanner) scanSource(
 	}
 
 	return getPackageMetadata(
-		pkgSource, builderPkgs, intermediatePkgs,
+		stageAlias, digestBase, builderPkgs, intermediatePkgs,
 	), nil
 }
 
-// getPackageMetadata uses the passed packageSource and its builder and intermediate
-// packages to return a slice of PackageMetadataItem structs to signify package origins.
+// getPackageMetadata maps scanned packages to PackageMetadataItem structs
+// with the given origin information.
 func getPackageMetadata(
-	pkgSource packageSource,
+	stageAlias string,
+	digestBase string,
 	builderPkgs []sbom.SyftPackage,
 	intermediatePkgs []sbom.SyftPackage,
 ) []PackageMetadataItem {
@@ -507,8 +707,8 @@ func getPackageMetadata(
 
 	for _, bpkg := range builderPkgs {
 		res = append(res, PackageMetadataItem{
-			Pullspec:         pkgSource.digestBase,
-			StageAlias:       pkgSource.alias,
+			Pullspec:         digestBase,
+			StageAlias:       stageAlias,
 			PackageURL:       bpkg.PURL,
 			DependencyOfPURL: bpkg.DependencyOfPURL,
 			Checksums:        bpkg.Checksums,
@@ -518,8 +718,8 @@ func getPackageMetadata(
 
 	for _, ipkg := range intermediatePkgs {
 		res = append(res, PackageMetadataItem{
-			Pullspec:         pkgSource.digestBase,
-			StageAlias:       pkgSource.alias,
+			Pullspec:         digestBase,
+			StageAlias:       stageAlias,
 			PackageURL:       ipkg.PURL,
 			DependencyOfPURL: ipkg.DependencyOfPURL,
 			Checksums:        ipkg.Checksums,

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -1296,6 +1296,61 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expectedExternals: []ExternalPackageSource{},
 		},
+		"external COPY --from in builder stage": {
+			stages: []containerfile.Stage{
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies: []containerfile.Copy{
+						{
+							From:        "docker.io/library/external:latest",
+							Sources:     []string{"/ext/bin"},
+							Destination: "/ext/bin",
+							Type:        containerfile.CopyTypeExternal,
+						},
+					},
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies: []containerfile.Copy{
+						{
+							From:        "builder",
+							Sources:     []string{"/app/", "/ext/bin"},
+							Destination: "/",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			digests: map[string]digest.Digest{
+				"docker.io/library/fedora:latest": testDigest("eee111"),
+				"docker.io/library/external:latest":       testDigest("fff222"),
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expectedRoots: []BuilderPackageSourceRoot{
+				{
+					index:      0,
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@" + string(testDigest("eee111")),
+					sources:    []string{"/app/"},
+				},
+			},
+			expectedExternals: []ExternalPackageSource{
+				{
+					pullspec:   "docker.io/library/external:latest",
+					digestBase: "docker.io/library/external@" + string(testDigest("fff222")),
+					sources:    []string{"/ext/bin"},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -36,16 +36,19 @@ func configWithWorkdir(workdir string) storageclient.OCIImageConfig {
 func TestGetPackageSources(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
-		stages   []containerfile.Stage
-		digests  map[string]digest.Digest
-		configs  map[string]storageclient.OCIImageConfig
-		expected []packageSource
+		stages            []containerfile.Stage
+		digests           map[string]digest.Digest
+		configs           map[string]storageclient.OCIImageConfig
+		expectedRoots     []BuilderPackageSourceRoot
+		expectedExternals []ExternalPackageSource
 	}{
 		"only external copy in final": {
 			stages: []containerfile.Stage{
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "docker.io/library/fedora:latest",
@@ -59,12 +62,10 @@ func TestGetPackageSources(t *testing.T) {
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("abc123"),
 			},
-			configs: map[string]storageclient.OCIImageConfig{
-				"docker.io/library/fedora:latest": configWithWorkdir("/"),
-			},
-			expected: []packageSource{
+			configs:       map[string]storageclient.OCIImageConfig{},
+			expectedRoots: []BuilderPackageSourceRoot{},
+			expectedExternals: []ExternalPackageSource{
 				{
-					alias:      "",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("abc123")),
 					sources:    []string{"/usr/bin/oras"},
@@ -74,18 +75,24 @@ func TestGetPackageSources(t *testing.T) {
 		"copies in final stage only": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias:  "builder2",
-					Base:   "docker.io/alpine/helm:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -110,31 +117,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("def456")),
 					sources:    []string{"/usr/bin/oras"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("ca0789")),
 					sources:    []string{"/usr/bin/helm"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"recursive multi-stage file copy": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -145,8 +159,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -165,31 +181,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("da0012")),
 					sources:    []string{"/usr/bin/oras"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("ea0345")),
 					sources:    []string{},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"recursive multi-stage file copy - mixed sources": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -200,8 +223,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -220,31 +245,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("fa0678")),
 					sources:    []string{"/usr/bin/oras"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("5a0901")),
 					sources:    []string{"/usr/bin/helm"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"multi-stage directory copy": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -261,8 +293,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -281,31 +315,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("ba0234")),
 					sources:    []string{"/usr/bin/oras", "/bin/*"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("0a0567")),
 					sources:    []string{"/app/"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"ignore non-copied content": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -316,8 +357,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -336,31 +379,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("bcd890")),
 					sources:    []string{},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("ef0123")),
 					sources:    []string{"/app/"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"complex multi-stage with multiple final copies": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -371,8 +421,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -403,31 +455,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("a1f456")),
 					sources:    []string{"/lib/libc.so", "/usr/bin/kubectl"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("b2f789")),
 					sources:    []string{"/tools/", "/usr/bin/helm"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"wildcard copy in final stage": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder",
@@ -443,25 +502,31 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("a1f456")),
 					sources:    []string{"/lib/*.so"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"wildcard traced through multiple stages": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -471,8 +536,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -490,31 +557,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("a1f456")),
 					sources:    []string{"/usr/lib/*.so"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("abcdef")),
 					sources:    []string{"/libs/*.so"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"mixed wildcards and regular files": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder",
@@ -530,25 +604,31 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("a1f456")),
 					sources:    []string{"/usr/bin/helm", "/lib/*.so", "/etc/config.txt"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"relative destination resolution": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/library/node:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/library/node:latest",
+					BaseRef: "docker.io/library/node:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						// explicit workdir takes precedence over base image workdir (/var/data)
 						{
@@ -568,8 +648,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -594,31 +676,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/library/node:latest":   configWithWorkdir("/var/data"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("aaa111")),
 					sources:    []string{"/usr/bin/app", "/usr/bin/tool"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/library/node:latest",
 					digestBase: "docker.io/library/node@" + string(testDigest("bbb222")),
 					sources:    []string{},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"mixed destinations with workdir variants": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/library/alpine:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/library/alpine:latest",
+					BaseRef: "docker.io/library/alpine:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						// absolute destination (no workdir resolution)
 						{
@@ -654,8 +743,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -692,31 +783,38 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/library/alpine:latest": configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("ccc333")),
 					sources:    []string{"/usr/bin/cli", "/etc/app.conf", "/src/app", "/etc/defaults.conf"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/library/alpine:latest",
 					digestBase: "docker.io/library/alpine@" + string(testDigest("ddd444")),
 					sources:    []string{},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"multi-stage tracing with workdir in intermediate stage": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/library/alpine:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/library/alpine:latest",
+					BaseRef: "docker.io/library/alpine:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder1",
@@ -728,8 +826,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: "builder3",
-					Base:  "docker.io/library/ubuntu:latest",
+					Alias:   "builder3",
+					Base:    "docker.io/library/ubuntu:latest",
+					BaseRef: "docker.io/library/ubuntu:latest",
+					Index:   2,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -740,8 +840,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder3",
@@ -762,42 +864,52 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/alpine:latest": configWithWorkdir("/"),
 				"docker.io/library/ubuntu:latest": configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("111999")),
 					sources:    []string{"/usr/bin/app"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/library/alpine:latest",
 					digestBase: "docker.io/library/alpine@" + string(testDigest("222000")),
 					sources:    []string{},
 				},
 				{
+					index:      2,
 					alias:      "builder3",
 					pullspec:   "docker.io/library/ubuntu:latest",
 					digestBase: "docker.io/library/ubuntu@" + string(testDigest("333111")),
 					sources:    []string{},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"different stages with different base image workdirs": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "go-builder",
-					Base:   "docker.io/library/golang:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "go-builder",
+					Base:    "docker.io/library/golang:latest",
+					BaseRef: "docker.io/library/golang:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias:  "node-builder",
-					Base:   "docker.io/library/node:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "node-builder",
+					Base:    "docker.io/library/node:latest",
+					BaseRef: "docker.io/library/node:latest",
+					Index:   1,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "go-runner",
-					Base:  "registry.example.com/go-runtime:v1",
+					Alias:   "go-runner",
+					Base:    "registry.example.com/go-runtime:v1",
+					BaseRef: "registry.example.com/go-runtime:v1",
+					Index:   2,
 					Copies: []containerfile.Copy{
 						{
 							From:        "go-builder",
@@ -808,8 +920,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: "node-runner",
-					Base:  "registry.example.com/nginx:v1",
+					Alias:   "node-runner",
+					Base:    "registry.example.com/nginx:v1",
+					BaseRef: "registry.example.com/nginx:v1",
+					Index:   3,
 					Copies: []containerfile.Copy{
 						{
 							From:        "node-builder",
@@ -820,8 +934,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "go-runner",
@@ -850,43 +966,52 @@ func TestGetPackageSources(t *testing.T) {
 				"registry.example.com/go-runtime:v1": configWithWorkdir("/app"),
 				"registry.example.com/nginx:v1":      configWithWorkdir("/usr/share/nginx/html"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "go-builder",
 					pullspec:   "docker.io/library/golang:latest",
 					digestBase: "docker.io/library/golang@" + string(testDigest("444222")),
 					sources:    []string{"/go/bin/server"},
 				},
 				{
+					index:      1,
 					alias:      "node-builder",
 					pullspec:   "docker.io/library/node:latest",
 					digestBase: "docker.io/library/node@" + string(testDigest("555333")),
 					sources:    []string{"/home/node/dist/bundle.js"},
 				},
 				{
+					index:      2,
 					alias:      "go-runner",
 					pullspec:   "registry.example.com/go-runtime:v1",
 					digestBase: "registry.example.com/go-runtime@" + string(testDigest("666444")),
 					sources:    []string{},
 				},
 				{
+					index:      3,
 					alias:      "node-runner",
 					pullspec:   "registry.example.com/nginx:v1",
 					digestBase: "registry.example.com/nginx@" + string(testDigest("777555")),
 					sources:    []string{},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"numeric index COPY --from in final stage with aliased stages": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "0",
@@ -903,25 +1028,31 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("aaa111")),
 					sources:    []string{"/usr/bin/app"},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 		"numeric index COPY --from in builder stage with aliased stages": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder1",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder1",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias: "builder2",
-					Base:  "docker.io/alpine/helm:latest",
+					Alias:   "builder2",
+					Base:    "docker.io/alpine/helm:latest",
+					BaseRef: "docker.io/alpine/helm:latest",
+					Index:   1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "0",
@@ -932,8 +1063,10 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 				{
-					Alias: containerfile.FinalStage,
-					Base:  "scratch",
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
 					Copies: []containerfile.Copy{
 						{
 							From:        "builder2",
@@ -952,20 +1085,216 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expected: []packageSource{
+			expectedRoots: []BuilderPackageSourceRoot{
 				{
+					index:      0,
 					alias:      "builder1",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("bbb222")),
 					sources:    []string{"/content"},
 				},
 				{
+					index:      1,
 					alias:      "builder2",
 					pullspec:   "docker.io/alpine/helm:latest",
 					digestBase: "docker.io/alpine/helm@" + string(testDigest("ccc333")),
 					sources:    []string{},
 				},
 			},
+			expectedExternals: []ExternalPackageSource{},
+		},
+		"chained stages - parent and child cascade": {
+			// FROM fedora AS parent    (non-chained, index 0)
+			// FROM parent AS child     (chained, index 1, BaseRef=parent)
+			// FROM scratch             (final, copies from child)
+			stages: []containerfile.Stage{
+				{
+					Alias:   "parent",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
+				},
+				{
+					Alias:   "child",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "parent",
+					Index:   1,
+					Copies:  []containerfile.Copy{},
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies: []containerfile.Copy{
+						{
+							From:        "child",
+							Sources:     []string{"/app/bin"},
+							Destination: "/app/bin",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			digests: map[string]digest.Digest{
+				"docker.io/library/fedora:latest": testDigest("aa1111"),
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expectedRoots: []BuilderPackageSourceRoot{
+				{
+					index:      0,
+					alias:      "parent",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@" + string(testDigest("aa1111")),
+					sources:    []string{"/app/bin"},
+					descendants: []*BuilderPackageSourceNode{
+						{
+							index:   1,
+							alias:   "child",
+							sources: []string{"/app/bin"},
+						},
+					},
+				},
+			},
+			expectedExternals: []ExternalPackageSource{},
+		},
+		"chained stages - empty child skipped": {
+			// FROM fedora AS parent        (non-chained, index 0)
+			// FROM parent AS empty-child   (chained, index 1, BaseRef=parent, no intermediate expected)
+			// FROM scratch                 (final, copies from empty-child)
+			stages: []containerfile.Stage{
+				{
+					Alias:   "parent",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
+				},
+				{
+					Alias:   "empty-child",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "parent",
+					Index:   1,
+					Copies:  []containerfile.Copy{},
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies: []containerfile.Copy{
+						{
+							From:        "empty-child",
+							Sources:     []string{"/usr/bin/tool"},
+							Destination: "/usr/bin/tool",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			digests: map[string]digest.Digest{
+				"docker.io/library/fedora:latest": testDigest("bb2222"),
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expectedRoots: []BuilderPackageSourceRoot{
+				{
+					index:      0,
+					alias:      "parent",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@" + string(testDigest("bb2222")),
+					sources:    []string{"/usr/bin/tool"},
+					descendants: []*BuilderPackageSourceNode{
+						{
+							index:   1,
+							alias:   "empty-child",
+							sources: []string{"/usr/bin/tool"},
+						},
+					},
+				},
+			},
+			expectedExternals: []ExternalPackageSource{},
+		},
+		"chained stages - diamond dependency": {
+			// FROM fedora AS shared   (non-chained, index 0)
+			// FROM shared AS left     (chained, index 1, BaseRef=shared)
+			// FROM shared AS right    (chained, index 2, BaseRef=shared)
+			// FROM scratch            (final, copies from both left and right)
+			stages: []containerfile.Stage{
+				{
+					Alias:   "shared",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
+				},
+				{
+					Alias:   "left",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "shared",
+					Index:   1,
+					Copies:  []containerfile.Copy{},
+				},
+				{
+					Alias:   "right",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "shared",
+					Index:   2,
+					Copies:  []containerfile.Copy{},
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies: []containerfile.Copy{
+						{
+							From:        "left",
+							Sources:     []string{"/left/bin"},
+							Destination: "/left/bin",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+						{
+							From:        "right",
+							Sources:     []string{"/right/bin"},
+							Destination: "/right/bin",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			digests: map[string]digest.Digest{
+				"docker.io/library/fedora:latest": testDigest("cc3333"),
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expectedRoots: []BuilderPackageSourceRoot{
+				{
+					index:      0,
+					alias:      "shared",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@" + string(testDigest("cc3333")),
+					sources:    []string{"/left/bin", "/right/bin"},
+					descendants: []*BuilderPackageSourceNode{
+						{
+							index:   1,
+							alias:   "left",
+							sources: []string{"/left/bin"},
+						},
+						{
+							index:   2,
+							alias:   "right",
+							sources: []string{"/right/bin"},
+						},
+					},
+				},
+			},
+			expectedExternals: []ExternalPackageSource{},
 		},
 	}
 
@@ -977,19 +1306,27 @@ func TestGetPackageSources(t *testing.T) {
 				test.digests, test.configs,
 			)
 
-			actual, err := getPackageSources(client, test.stages, test.digests)
+			roots, externals, err := getPackageSources(client, test.stages, test.digests)
 			if err != nil {
 				t.Fatalf("getPackageSources returned error: %v", err)
 			}
 
-			diff := cmp.Diff(
-				test.expected, actual,
-				cmp.AllowUnexported(packageSource{}),
-				cmpopts.SortSlices(func(a, b packageSource) bool { return a.alias < b.alias }),
+			rootDiff := cmp.Diff(
+				test.expectedRoots, roots,
+				cmp.AllowUnexported(BuilderPackageSourceRoot{}, BuilderPackageSourceNode{}),
 				cmpopts.EquateEmpty(),
 			)
-			if diff != "" {
-				t.Errorf("getPackageSources() mismatch (-want +got):\n%s", diff)
+			if rootDiff != "" {
+				t.Errorf("getPackageSources() roots mismatch (-want +got):\n%s", rootDiff)
+			}
+
+			externalDiff := cmp.Diff(
+				test.expectedExternals, externals,
+				cmp.AllowUnexported(ExternalPackageSource{}),
+				cmpopts.EquateEmpty(),
+			)
+			if externalDiff != "" {
+				t.Errorf("getPackageSources() externals mismatch (-want +got):\n%s", externalDiff)
 			}
 		})
 	}
@@ -1041,14 +1378,18 @@ func TestGetPackageSourcesError(t *testing.T) {
 		"GetImageConfig error": {
 			stages: []containerfile.Stage{
 				{
-					Alias:  "builder",
-					Base:   "docker.io/library/fedora:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   "builder",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies:  []containerfile.Copy{},
 				},
 				{
-					Alias:  containerfile.FinalStage,
-					Base:   "docker.io/library/ubi9:latest",
-					Copies: []containerfile.Copy{},
+					Alias:   containerfile.FinalStage,
+					Base:    "docker.io/library/ubi9:latest",
+					BaseRef: "docker.io/library/ubi9:latest",
+					Index:   -1,
+					Copies:  []containerfile.Copy{},
 				},
 			},
 			configs:     map[string]storageclient.OCIImageConfig{},
@@ -1064,7 +1405,7 @@ func TestGetPackageSourcesError(t *testing.T) {
 				test.digests, test.configs,
 			)
 
-			_, err := getPackageSources(client, test.stages, test.digests)
+			_, _, err := getPackageSources(client, test.stages, test.digests)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}


### PR DESCRIPTION
Chained stages (FROM parent-alias AS child-alias) now correctly resolve their builder base and trace content through parent chains. Empty chained stages (with no fs-changing instructions) are skipped.