### PR TITLE
fix: handle external COPY --from in builder stages

### DIFF
--- a/pkg/content.go
+++ b/pkg/content.go
@@ -105,7 +105,7 @@ func (s *Scanner) getDescendantContent(
 		return nil, nil, fmt.Errorf("%w: failed to find intermediate image for %q: %w", ErrStorage, stageAlias, err)
 	}
 	if !found {
-		// no intermediate image found for node — pass diffBase through unchanged
+		// no intermediate image found for node - pass diffBase through unchanged
 		s.logger.Debug("no intermediate image found for chained stage, skipping", "stage", stageAlias)
 		return diffBase, nil, nil
 	}

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -88,6 +88,32 @@ func (s *Scanner) logContent(kind string, content []string, pullspec string) {
 	}
 }
 
+// getExternalContent extracts content from an external image (COPY --from=image:tag).
+// External images have no intermediate layer — only the image content is extracted.
+func (s *Scanner) getExternalContent(
+	pullspec string,
+	sources []string,
+	contentPath string,
+) error {
+	imgID, err := s.store.Lookup(storageclient.StripTransport(pullspec))
+	if err != nil {
+		return fmt.Errorf("could not find external image %q in buildah storage: %w", pullspec, ErrImageNotFound)
+	}
+
+	img, err := s.store.Image(imgID)
+	if err != nil {
+		return fmt.Errorf("could not find external image %q in buildah storage: %w", pullspec, ErrImageNotFound)
+	}
+
+	content, err := s.getImageContent(img, sources, contentPath)
+	if err != nil {
+		return err
+	}
+
+	s.logContent("external", content, pullspec)
+	return nil
+}
+
 // getDescendantContent extracts intermediate content for a chained stage (node)
 // by diffing its intermediate image against the provided diff base image.
 // Returns the node's intermediate image and the list of extracted paths.

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1235,7 +1235,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[Chained stages / external content] Content traced through intermediate builder via COPY chain with external image": {
-			SkipTestReason: "[Priority: high] chained stages not yet supported, bug with external image in builder stage unresolved",
 			TestImage: BuildDefinition{
 				Tag: "test-chain-with-external",
 				ContainerfileContent: `FROM localhost/base-img:latest AS builder
@@ -1285,13 +1284,11 @@ func TestIntegration(t *testing.T) {
 						PackageURL: "pkg:golang/golang.org/x/text@v0.18.0",
 						OriginType: "external",
 						Pullspec:   "localhost/in-chain-ext@sha256:dummy",
-						StageAlias: "builder",
 					},
 				},
 			},
 		},
 		"[External content] External COPY in final stage": {
-			SkipTestReason: "[Priority: medium] origin_type 'external' not yet implemented - capo reports external content as 'builder'. Works otherwise.",
 			TestImage: BuildDefinition{
 				Tag: "test-external-copy-final",
 				ContainerfileContent: `FROM localhost/builder-base:latest AS builder
@@ -1348,7 +1345,6 @@ func TestIntegration(t *testing.T) {
 		// modeled as DESCENDANT_OF builder base image — external image content in a
 		// builder stage has no such relationship to the builder base.
 		"[External content] External COPY in builder stage - content traced through builder to final": {
-			SkipTestReason: "[Priority: high] bug: traceSource panic on nil stage from external COPY --from in builder",
 			TestImage: BuildDefinition{
 				Tag: "test-external-copy-in-builder",
 				ContainerfileContent: `FROM localhost/builder-base:latest AS builder

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -77,7 +77,7 @@ type PackageMetadataItem struct {
 	// found multiple times as a dependency of different packages.
 	DependencyOfPURL string `json:"dependency_of_purl,omitempty"`
 
-	// Type of origin of this package, can be "builder" or "intermediate".
+	// Type of origin of this package, can be "builder", "intermediate" or "external".
 	OriginType string `json:"origin_type"`
 
 	// Pullspec of the image with digest which is this package's origin.
@@ -209,7 +209,7 @@ func (s *Scanner) Scan(
 	}
 
 	for _, ext := range externals {
-		extPkgItems, err := s.scanSource(ext.pullspec, "", ext.digestBase, ext.sources)
+		extPkgItems, err := s.scanExternalSource(ext)
 		if err != nil {
 			return PackageMetadata{}, fmt.Errorf("failed to scan external source %+v: %w", ext, err)
 		}
@@ -335,7 +335,7 @@ func getPackageSources(
 			// Multiple copies from same external image (multiple COPY instructions referencing same image,
 			// not sources) are grouped under same pullspec.
 			if idx, isBuilder := aliasToIndex[cp.From]; isBuilder {
-				traceSource(source, idx, builderStageAcc, indexToStage, aliasToIndex, baseToWorkdir)
+				traceSource(source, idx, builderStageAcc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
 			} else {
 				externalAcc[cp.From] = append(externalAcc[cp.From], source)
 			}
@@ -440,6 +440,7 @@ func buildSourceTree(
 
 // traceSource recursively traces a source path through builder stage COPY
 // commands to find its true origin. Maps stage indices to source paths in acc.
+// External COPY --from references in builder stages are collected in externalAcc.
 // baseToWorkdir is a mapping of bases of stages in the containerfile and their
 // respective initial working directories.
 func traceSource(
@@ -448,6 +449,7 @@ func traceSource(
 	acc map[int][]string,
 	indexToStage map[int]*containerfile.Stage,
 	aliasToIndex map[string]int,
+	externalAcc map[string][]string,
 	baseToWorkdir map[string]string,
 ) {
 	currStage := indexToStage[stageIndex]
@@ -477,7 +479,13 @@ func traceSource(
 				coversMultipleFiles = true
 			}
 			for _, s := range cp.Sources {
-				traceSource(s, aliasToIndex[cp.From], acc, indexToStage, aliasToIndex, baseToWorkdir)
+				if nextIdx, ok := aliasToIndex[cp.From]; ok {
+					// builder stage - continue tracing
+					traceSource(s, nextIdx, acc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
+				} else {
+					// external image - add as external source
+					externalAcc[cp.From] = append(externalAcc[cp.From], s)
+				}
 			}
 		}
 	}
@@ -492,7 +500,7 @@ func traceSource(
 
 	// chained stage — propagate source to parent for builder content scanning
 	if parentIdx, ok := aliasToIndex[currStage.BaseRef]; ok {
-		traceSource(source, parentIdx, acc, indexToStage, aliasToIndex, baseToWorkdir)
+		traceSource(source, parentIdx, acc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
 	}
 }
 
@@ -636,6 +644,42 @@ func (s *Scanner) scanDescendants(
 	return res, nil
 }
 
+// scanExternalSource scans content from an external image (COPY --from=image:tag).
+// External images have no intermediate layer - only the image content is extracted
+// and reported with origin_type "external".
+func (s *Scanner) scanExternalSource(
+	ext ExternalPackageSource,
+) (_ []PackageMetadataItem, err error) {
+	contentPath, err := os.MkdirTemp("", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w: %w", err, ErrIO)
+	}
+
+	debugMode := os.Getenv("CAPO_DEBUG") != ""
+	if debugMode {
+		s.logger.Debug("external content path", "pullspec", ext.pullspec, "path", contentPath)
+	} else {
+		defer func() {
+			removeErr := os.RemoveAll(contentPath)
+			if err == nil {
+				err = removeErr
+			}
+		}()
+	}
+
+	err = s.getExternalContent(ext.pullspec, ext.sources, contentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs, err := sbom.SyftScan(contentPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan external content: %w: %w", err, ErrSBOMScan)
+	}
+
+	return getPackageMetadata("", ext.digestBase, "external", pkgs, nil), nil
+}
+
 // scanSource extracts content for a stage from buildah storage, scans it
 // with syft, and returns package metadata items.
 func (s *Scanner) scanSource(
@@ -690,7 +734,7 @@ func (s *Scanner) scanSource(
 	}
 
 	return getPackageMetadata(
-		stageAlias, digestBase, builderPkgs, intermediatePkgs,
+		stageAlias, digestBase, "builder", builderPkgs, intermediatePkgs,
 	), nil
 }
 
@@ -699,6 +743,7 @@ func (s *Scanner) scanSource(
 func getPackageMetadata(
 	stageAlias string,
 	digestBase string,
+	builderOriginType string,
 	builderPkgs []sbom.SyftPackage,
 	intermediatePkgs []sbom.SyftPackage,
 ) []PackageMetadataItem {
@@ -711,7 +756,7 @@ func getPackageMetadata(
 			PackageURL:       bpkg.PURL,
 			DependencyOfPURL: bpkg.DependencyOfPURL,
 			Checksums:        bpkg.Checksums,
-			OriginType:       "builder",
+			OriginType:       builderOriginType,
 		})
 	}
 

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -1296,6 +1296,61 @@ func TestGetPackageSources(t *testing.T) {
 			},
 			expectedExternals: []ExternalPackageSource{},
 		},
+		"external COPY --from in builder stage": {
+			stages: []containerfile.Stage{
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/fedora:latest",
+					BaseRef: "docker.io/library/fedora:latest",
+					Index:   0,
+					Copies: []containerfile.Copy{
+						{
+							From:        "docker.io/library/external:latest",
+							Sources:     []string{"/ext/bin"},
+							Destination: "/ext/bin",
+							Type:        containerfile.CopyTypeExternal,
+						},
+					},
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies: []containerfile.Copy{
+						{
+							From:        "builder",
+							Sources:     []string{"/app/", "/ext/bin"},
+							Destination: "/",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			digests: map[string]digest.Digest{
+				"docker.io/library/fedora:latest": testDigest("eee111"),
+				"docker.io/library/external:latest":       testDigest("fff222"),
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expectedRoots: []BuilderPackageSourceRoot{
+				{
+					index:      0,
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@" + string(testDigest("eee111")),
+					sources:    []string{"/app/"},
+				},
+			},
+			expectedExternals: []ExternalPackageSource{
+				{
+					pullspec:   "docker.io/library/external:latest",
+					digestBase: "docker.io/library/external@" + string(testDigest("fff222")),
+					sources:    []string{"/ext/bin"},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
traceSource no longer panics on COPY --from=image:tag in builder stages. External content is now scanned separately via getExternalContent and reported with origin_type "external" instead of "builder".