### PR TITLE
fix: resolve numeric COPY --from index when stages have aliases

### DIFF
--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1543,8 +1543,7 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 		},
-		"[Numeric index COPY --from] COPY --from with numeric index in final stage": {
-			SkipTestReason: "[Priority: medium/high] COPY --from=0 resolved as pullspec instead of stage index when stage has alias (fails with 'could not find resolved pullspec')",
+		"[Numeric index COPY --from] COPY --from with numeric index in final stage (stage has alias)": {
 			TestImage: BuildDefinition{
 				Tag: "test-numeric-copy-from-final",
 				ContainerfileContent: `FROM localhost/numfinal-base:latest AS builder
@@ -1575,8 +1574,7 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 		},
-		"[Numeric index COPY --from] COPY --from with numeric index in builder stage": {
-			SkipTestReason: "[Priority: high] COPY --from=0 in builder stage causes nil pointer panic in traceSource when stage has alias (same as in External COPY in builder stage... test)",
+		"[Numeric index COPY --from] COPY --from with numeric index in builder stage (stages have alias)": {
 			TestImage: BuildDefinition{
 				Tag: "test-numeric-copy-from-builder",
 				ContainerfileContent: `FROM localhost/numbuilder-base1:latest AS builder1
@@ -1588,7 +1586,7 @@ func TestIntegration(t *testing.T) {
 										COPY go_text.mod /untracked/b2/go.mod
 
 										FROM scratch
-										COPY --from=builder2 /forwarded /forwarded`,
+										COPY --from=1 /forwarded /forwarded`,
 				ContextDirectory: "../testdata/image_content",
 			},
 			BuilderImages: []BuildDefinition{

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/konflux-ci/capo/internal/sbom"
@@ -208,6 +209,9 @@ func getPackageSources(
 	for i := range stages[:len(stages)-1] {
 		st := &stages[i]
 		aliasToStage[st.Alias] = st
+		// also map numeric index so COPY --from=<index> resolves
+		// correctly even when stage aliases are present
+		aliasToStage[strconv.Itoa(i)] = st
 	}
 
 	// mapping of bases used in the containerfile to their initial working

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -877,6 +877,96 @@ func TestGetPackageSources(t *testing.T) {
 				},
 			},
 		},
+		"numeric index COPY --from in final stage with aliased stages": {
+			stages: []containerfile.Stage{
+				{
+					Alias:  "builder",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
+				},
+				{
+					Alias: containerfile.FinalStage,
+					Base:  "scratch",
+					Copies: []containerfile.Copy{
+						{
+							From:        "0",
+							Sources:     []string{"/usr/bin/app"},
+							Destination: "/usr/bin/app",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			digests: map[string]digest.Digest{
+				"docker.io/library/fedora:latest": testDigest("aaa111"),
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expected: []packageSource{
+				{
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@" + string(testDigest("aaa111")),
+					sources:    []string{"/usr/bin/app"},
+				},
+			},
+		},
+		"numeric index COPY --from in builder stage with aliased stages": {
+			stages: []containerfile.Stage{
+				{
+					Alias:  "builder1",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
+				},
+				{
+					Alias: "builder2",
+					Base:  "docker.io/alpine/helm:latest",
+					Copies: []containerfile.Copy{
+						{
+							From:        "0",
+							Sources:     []string{"/content"},
+							Destination: "/forwarded",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+				{
+					Alias: containerfile.FinalStage,
+					Base:  "scratch",
+					Copies: []containerfile.Copy{
+						{
+							From:        "builder2",
+							Sources:     []string{"/forwarded"},
+							Destination: "/forwarded",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			digests: map[string]digest.Digest{
+				"docker.io/library/fedora:latest": testDigest("bbb222"),
+				"docker.io/alpine/helm:latest":    testDigest("ccc333"),
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
+			},
+			expected: []packageSource{
+				{
+					alias:      "builder1",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@" + string(testDigest("bbb222")),
+					sources:    []string{"/content"},
+				},
+				{
+					alias:      "builder2",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@" + string(testDigest("ccc333")),
+					sources:    []string{},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
aliasToStage now maps both stage aliases and numeric indices, so COPY --from=<index> resolves correctly even when stages have explicit aliases.