### PR TITLE
fix(ISV-7171): handle RUN --mount content

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,6 +36,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libgpgme-dev libseccomp-dev
 
+    - name: Install crun >= 1.14.3 (required for OCI runtime spec v1.2.1)
+      run: |
+        CRUN_VERSION=1.27.1
+        curl -fsSL "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64" -o /tmp/crun
+        sudo install -m 0755 /tmp/crun /usr/bin/crun
+
     - name: Build custom buildah with intermediate image labeling support
       run: mage BuildCustomBuildah
 

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -75,7 +75,7 @@ const (
 type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final.
 	Alias string
-	// Base image for the stage. Can be a pullspec, "scratch", or "oci:archive".
+	// Base image for the stage. Can be a pullspec, "scratch", or "oci-archive".
 	Base string
 	// Builder copies in this stage in order (top to bottom in the containerfile).
 	Copies []Copy

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -59,6 +59,9 @@ type Mount struct {
 	// Type of the mount. Specifies whether it references a builder stage
 	// or an external image directly.
 	Type MountType
+	// Subdirectory of the source image/stage to mount. Defaults to "/".
+	// Corresponds to the source=/src= option in --mount.
+	Source string
 }
 
 // MountType classifies a RUN --mount reference by its source origin.
@@ -251,6 +254,18 @@ func isStageRef(ref string, stageNames []string) bool {
 	return false
 }
 
+// getOptionValue returns the value of the option with the given aliases.
+// If the option is not found, it returns an empty string and false.
+// Its input is expected to be in format "alias=value".
+func getOptionValue(rawOpt string, aliases... string) (string, bool) {
+	for _, alias := range aliases {
+		if val, ok := strings.CutPrefix(rawOpt, alias+"="); ok {
+			return val, true
+		}
+	}
+	return "", false
+}
+
 // parseMounts extracts Mount references from a RUN instruction's --mount flags.
 // Only mounts with a "from" option are returned. Uses the passed previous stage
 // names to classify whether the mount references a builder stage or an external image.
@@ -260,35 +275,66 @@ func parseMounts(node *parser.Node, env []string, stageNames []string) ([]Mount,
 		if !strings.HasPrefix(fl, "--mount=") {
 			continue
 		}
+		mount, err := parseMount(strings.TrimPrefix(fl, "--mount="), env, stageNames)
+		if err != nil {
+			return nil, err
+		}
+		if mount != nil {
+			mounts = append(mounts, *mount)
+		}
+	}
+	return mounts, nil
+}
 
-		mountOpts := strings.TrimPrefix(fl, "--mount=")
-		from := ""
-		for opt := range strings.SplitSeq(mountOpts, ",") {
-			if val, ok := strings.CutPrefix(opt, "from="); ok {
+// parseMount parses a single --mount option string (without the --mount= prefix)
+// and returns a Mount if it is a bind mount with a from reference, or nil otherwise.
+func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, error) {
+	var from, source, buildahMountType string
+	for opt := range strings.SplitSeq(mountOpts, ",") {
+		if from == "" {
+			if val, ok := getOptionValue(opt, "from"); ok {
 				var err error
 				from, err = imagebuilder.ProcessWord(val, env)
 				if err != nil {
 					return nil, fmt.Errorf("%w: %w", ErrParse, err)
 				}
-				break
+				continue
 			}
 		}
-
-		if from == "" {
-			continue
+		if source == "" {
+			if val, ok := getOptionValue(opt, "source", "src"); ok {
+				source = val
+				continue
+			}
 		}
-
-		mountType := MountTypeBuilder
-		if !isStageRef(from, stageNames) {
-			mountType = MountTypeExternal
+		if buildahMountType == "" {
+			if val, ok := getOptionValue(opt, "type"); ok {
+				buildahMountType = val
+				continue
+			}
 		}
-
-		mounts = append(mounts, Mount{
-			From: from,
-			Type: mountType,
-		})
 	}
-	return mounts, nil
+
+	if from == "" || buildahMountType != "bind" {
+		return nil, nil
+	}
+
+	if source == "" {
+		source = "/"
+	} else {
+		source = filepath.Join("/", source)
+	}
+
+	mountType := MountTypeBuilder
+	if !isStageRef(from, stageNames) {
+		mountType = MountTypeExternal
+	}
+
+	return &Mount{
+		From:   from,
+		Type:   mountType,
+		Source: source,
+	}, nil
 }
 
 // normalizeSources normalizes the paths in the passed sources slice to absolute clean paths.

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -450,7 +450,7 @@ func TestParse(t *testing.T) {
 					Base:   "quay.io/rhel:9",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "quay.io/tools:1", Type: MountTypeExternal},
+						{From: "quay.io/tools:1", Type: MountTypeExternal, Source: "/bin/tool"},
 					},
 				},
 			},
@@ -471,7 +471,7 @@ func TestParse(t *testing.T) {
 					Base:   "scratch",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "builder", Type: MountTypeBuilder},
+						{From: "builder", Type: MountTypeBuilder, Source: "/app"},
 					},
 				},
 			},
@@ -492,7 +492,56 @@ func TestParse(t *testing.T) {
 					Base:   "scratch",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "0", Type: MountTypeBuilder},
+						{From: "0", Type: MountTypeBuilder, Source: "/app"},
+					},
+				},
+			},
+		},
+		"RUN --mount source and target defaults to root": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							FROM scratch
+							RUN --mount=type=bind,from=builder,target=/mnt ls /mnt`,
+			expected: []Stage{
+				{
+					Alias:  "builder",
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+				},
+				{
+					Alias:  FinalStage,
+					Base:   "scratch",
+					Copies: []Copy{},
+					Mounts: []Mount{
+						{From: "builder", Type: MountTypeBuilder, Source: "/"},
+					},
+				},
+			},
+		},
+		"RUN --mount destination= alias for target": {
+			containerfile: `FROM quay.io/rhel:9
+							RUN --mount=type=bind,from=quay.io/tools:1,destination=/mnt ls /mnt`,
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{
+						{From: "quay.io/tools:1", Type: MountTypeExternal, Source: "/"},
+					},
+				},
+			},
+		},
+		"RUN --mount source= alias for src": {
+			containerfile: `FROM quay.io/rhel:9
+							RUN --mount=type=bind,from=quay.io/tools:1,source=/specific/dir,target=/mnt ls /mnt`,
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{
+						{From: "quay.io/tools:1", Type: MountTypeExternal, Source: "/specific/dir"},
 					},
 				},
 			},

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/konflux-ci/capo/pkg/storageclient"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/archive"
 )
@@ -49,13 +50,23 @@ func getContent(
 	builderContentPath string,
 	intermediateContentPath string,
 ) error {
-	imgId, err := store.Lookup(pkgSource.pullspec)
-	if err != nil {
-		return fmt.Errorf("%w: %q", ErrImageNotFound, pkgSource.pullspec)
-	}
-	img, _ := store.Image(imgId)
+	var builderImage *storage.Image = nil
 
-	intermediate, err := getIntermediateContent(store, img, pkgSource.alias, pkgSource.sources, intermediateContentPath)
+	if !storageclient.IsSpecialBase(pkgSource.pullspec) {
+		imgId, err := store.Lookup(storageclient.StripTransport(pkgSource.pullspec))
+		if err != nil {
+			return fmt.Errorf("%w: %q", ErrImageNotFound, pkgSource.pullspec)
+		}
+		builderImage, _ = store.Image(imgId)
+	}
+
+	intermediate, err := getIntermediateContent(
+		store,
+		builderImage,
+		pkgSource.alias,
+		pkgSource.sources,
+		intermediateContentPath,
+	)
 	if err != nil {
 		return err
 	}
@@ -66,7 +77,12 @@ func getContent(
 		log.Printf("Included intermediate content %+v for %s.", intermediate, pkgSource.pullspec)
 	}
 
-	builder, err := getImageContent(store, img, pkgSource.sources, builderContentPath)
+	if builderImage == nil {
+		log.Printf("No builder image found for %s.", pkgSource.pullspec)
+		return nil
+	}
+
+	builder, err := getImageContent(store, builderImage, pkgSource.sources, builderContentPath)
 	if err != nil {
 		return err
 	}
@@ -204,6 +220,9 @@ func copyFile(src string, dest string) (err error) {
 // Uses buildah stage labels (io.buildah.stage.name) to find the intermediate
 // image for the given stage, then calculates a diff between the intermediate
 // top layer and the builder base image top layer.
+//
+// When builderImage is nil (special bases like scratch or oci-archive), diffs
+// against an empty parent to capture all content added during the stage.
 func getIntermediateContent(
 	store storage.Store,
 	builderImage *storage.Image,
@@ -211,9 +230,13 @@ func getIntermediateContent(
 	sources []string,
 	path string,
 ) ([]string, error) {
-	builderLayer, err := store.Layer(builderImage.TopLayer)
-	if err != nil {
-		return []string{}, fmt.Errorf("%w: failed to get builder layer: %w", ErrStorage, err)
+	var parentLayerID string
+	if builderImage != nil {
+		builderLayer, err := store.Layer(builderImage.TopLayer)
+		if err != nil {
+			return []string{}, fmt.Errorf("%w: failed to get builder layer: %w", ErrStorage, err)
+		}
+		parentLayerID = builderLayer.ID
 	}
 
 	// Find intermediate image using buildah stage labels
@@ -231,7 +254,7 @@ func getIntermediateContent(
 		return []string{}, fmt.Errorf("%w: failed to get intermediate layer: %w", ErrStorage, err)
 	}
 
-	included, err := saveDiff(store, path, interLayer.ID, builderLayer.ID, sources)
+	included, err := saveDiff(store, path, interLayer.ID, parentLayerID, sources)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -51,7 +51,7 @@ func getContent(
 	intermediateContentPath string,
 ) error {
 	isSpecialBase := storageclient.IsSpecialBase(pkgSource.pullspec)
-	var builderImage *storage.Image = nil
+	var builderImage *storage.Image
 
 	if !isSpecialBase {
 		// Special bases are not pullable or resolvable with Lookup
@@ -75,7 +75,7 @@ func getContent(
 	logContent("intermediate", intermediate, pkgSource.pullspec)
 
 	if !isSpecialBase {
-		// Only standard bases have bulder content. All content in special bases is treated as intermediate.
+		// Only standard bases have builder content. All content in special bases is treated as intermediate.
 		builderContent, err := getImageContent(store, builderImage, pkgSource.sources, builderContentPath)
 		if err != nil {
 			return err

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -50,45 +50,48 @@ func getContent(
 	builderContentPath string,
 	intermediateContentPath string,
 ) error {
+	isSpecialBase := storageclient.IsSpecialBase(pkgSource.pullspec)
 	var builderImage *storage.Image = nil
 
-	if !storageclient.IsSpecialBase(pkgSource.pullspec) {
+	if !isSpecialBase {
+		// Special bases are not pullable or resolvable with Lookup
 		imgId, err := store.Lookup(storageclient.StripTransport(pkgSource.pullspec))
 		if err != nil {
 			return fmt.Errorf("%w: %q", ErrImageNotFound, pkgSource.pullspec)
 		}
-		builderImage, _ = store.Image(imgId)
+		builderImage, err = store.Image(imgId)
+		if err != nil {
+			return fmt.Errorf("%w: %q", ErrImageNotFound, pkgSource.pullspec)
+		}
 	}
 
+	// Special bases will have builderImage set as nil
 	intermediate, err := getIntermediateContent(
-		store,
-		builderImage,
-		pkgSource.alias,
-		pkgSource.sources,
-		intermediateContentPath,
+		store, builderImage, pkgSource.alias, pkgSource.sources, intermediateContentPath,
 	)
 	if err != nil {
 		return err
 	}
+	logContent("intermediate", intermediate, pkgSource.pullspec)
 
-	if len(intermediate) == 0 {
-		log.Printf("Found no intermediate content for %s.", pkgSource.pullspec)
-	} else {
-		log.Printf("Included intermediate content %+v for %s.", intermediate, pkgSource.pullspec)
+	if !isSpecialBase {
+		// Only standard bases have bulder content. All content in special bases is treated as intermediate.
+		builderContent, err := getImageContent(store, builderImage, pkgSource.sources, builderContentPath)
+		if err != nil {
+			return err
+		}
+		logContent("builder", builderContent, pkgSource.pullspec)
 	}
-
-	if builderImage == nil {
-		log.Printf("No builder image found for %s.", pkgSource.pullspec)
-		return nil
-	}
-
-	builder, err := getImageContent(store, builderImage, pkgSource.sources, builderContentPath)
-	if err != nil {
-		return err
-	}
-	log.Printf("Included builder content %+v for %s.", builder, pkgSource.pullspec)
 
 	return nil
+}
+
+func logContent(kind string, content []string, pullspec string) {
+	if len(content) == 0 {
+		log.Printf("Found no %s content for %s.", kind, pullspec)
+	} else {
+		log.Printf("Included %s content %+v for %s.", kind, content, pullspec)
+	}
 }
 
 // IsPathUnderPattern reports whether path matches pattern exactly (via filepath.Match)
@@ -221,8 +224,10 @@ func copyFile(src string, dest string) (err error) {
 // image for the given stage, then calculates a diff between the intermediate
 // top layer and the builder base image top layer.
 //
-// When builderImage is nil (special bases like scratch or oci-archive), diffs
-// against an empty parent to capture all content added during the stage.
+// When builderImage is nil (special bases like scratch or oci-archive), mounts
+// the intermediate image and reads all matching content. Filesystem-transport
+// bases are local files with non-pullable identifiers, so all their content
+// is treated uniformly as intermediate.
 func getIntermediateContent(
 	store storage.Store,
 	builderImage *storage.Image,
@@ -230,16 +235,6 @@ func getIntermediateContent(
 	sources []string,
 	path string,
 ) ([]string, error) {
-	var parentLayerID string
-	if builderImage != nil {
-		builderLayer, err := store.Layer(builderImage.TopLayer)
-		if err != nil {
-			return []string{}, fmt.Errorf("%w: failed to get builder layer: %w", ErrStorage, err)
-		}
-		parentLayerID = builderLayer.ID
-	}
-
-	// Find intermediate image using buildah stage labels
 	intermediateImage, found, err := findIntermediateImage(store, stageAlias)
 	if err != nil {
 		return []string{}, fmt.Errorf("%w: failed to find intermediate image: %w", ErrStorage, err)
@@ -249,12 +244,22 @@ func getIntermediateContent(
 		return []string{}, nil
 	}
 
+	if builderImage == nil {
+		// Scratch or unresolvable (special) bases
+		return getImageContent(store, intermediateImage, sources, path)
+	}
+
+	builderLayer, err := store.Layer(builderImage.TopLayer)
+	if err != nil {
+		return []string{}, fmt.Errorf("%w: failed to get builder layer: %w", ErrStorage, err)
+	}
+
 	interLayer, err := store.Layer(intermediateImage.TopLayer)
 	if err != nil {
 		return []string{}, fmt.Errorf("%w: failed to get intermediate layer: %w", ErrStorage, err)
 	}
 
-	included, err := saveDiff(store, path, interLayer.ID, parentLayerID, sources)
+	included, err := saveDiff(store, path, interLayer.ID, builderLayer.ID, sources)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1755,6 +1755,9 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 		},
+		// All content from oci-archive is treated as intermediate content,
+		// even if it is from a builder stage. That is because all oci-archive
+		// bases are local and unpullable.
 		"[FROM special] FROM oci-archive as builder base": {
 			TestImage: BuildDefinition{
 				Tag: "test-from-oci-archive-builder",
@@ -1762,7 +1765,8 @@ func TestIntegration(t *testing.T) {
 										COPY go_uuid.mod /content/go.mod
 
 										FROM scratch
-										COPY --from=builder /content /content`,
+										COPY --from=builder /content /content
+										COPY --from=builder /opt /opt`,
 				ContextDirectory: "../testdata/image_content",
 			},
 			BuilderImages: []BuildDefinition{
@@ -1778,6 +1782,12 @@ func TestIntegration(t *testing.T) {
 				Packages: []PackageMetadataItem{
 					{
 						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
+						OriginType: "intermediate",
+						Pullspec:   "oci-archive:test-base.ociarchive",
+						StageAlias: "builder",
+					},
+					{
+						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
 						OriginType: "intermediate",
 						Pullspec:   "oci-archive:test-base.ociarchive",
 						StageAlias: "builder",

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1802,14 +1802,16 @@ func TestIntegration(t *testing.T) {
 										COPY go_uuid.mod /content/go.mod
 
 										FROM scratch
-										COPY --from=builder /content /content`,
+										COPY --from=builder /content /content
+										COPY --from=builder /C /content`,
 				ContextDirectory: "../testdata/image_content",
 			},
 			BuilderImages: []BuildDefinition{
 				{
 					Tag: "localhost/docker-transport-base:latest",
 					ContainerfileContent: `FROM scratch
-											COPY go2.mod /base/go.mod`,
+											COPY go2.mod /base/go.mod
+											COPY go_syft.mod /C/Users/Shadowman/Desktop/go.mod`,
 					ContextDirectory: "../testdata/image_content",
 				},
 			},
@@ -1818,6 +1820,12 @@ func TestIntegration(t *testing.T) {
 					{
 						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
 						OriginType: "intermediate",
+						Pullspec:   "localhost/docker-transport-base@sha256:dummy",
+						StageAlias: "builder",
+					},
+					{
+						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
+						OriginType: "builder",
 						Pullspec:   "localhost/docker-transport-base@sha256:dummy",
 						StageAlias: "builder",
 					},

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -16,9 +16,32 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/konflux-ci/capo/pkg/containerfile"
+	"github.com/konflux-ci/capo/pkg/storageclient"
 	"github.com/magefile/mage/sh"
 	"go.podman.io/storage"
 )
+
+// splitFilesystemTransport splits a filesystem transport reference into the
+// transport prefix and the remaining path+reference. For example
+// "oci-archive:image.tar:latest" returns ("oci-archive:", "image.tar:latest").
+// Returns ("", pullspec) if the pullspec does not use a filesystem transport.
+func splitFilesystemTransport(pullspec string) (transport, rest string) {
+	for _, prefix := range []string{"oci-archive:", "docker-archive:", "oci:", "dir:"} {
+		if after, ok := strings.CutPrefix(pullspec, prefix); ok {
+			return prefix, after
+		}
+	}
+	return "", pullspec
+}
+
+// filesystemTransportPath extracts the local file/directory path from a
+// filesystem transport reference. For example "oci-archive:image.tar:latest"
+// returns "image.tar".
+func filesystemTransportPath(pullspec string) string {
+	_, rest := splitFilesystemTransport(pullspec)
+	path, _, _ := strings.Cut(rest, ":")
+	return path
+}
 
 // BuildDefinition describes a container image to build for a test.
 type BuildDefinition struct {
@@ -118,13 +141,56 @@ func (testCase *TestCase) run(t *testing.T, store storage.Store, buildahBinary s
 
 // buildImage builds a container image from a containerfile using buildah.
 // Skips building if the image already exists and isBuilder is true.
+//
+// When Tag uses a filesystem transport (e.g. "oci-archive:base.tar:latest"),
+// the image is built with a temporary tag, pushed to a local file/directory
+// inside the ContextDirectory using the original transport, and the temporary
+// image is removed from storage. This is needed because buildah requires
+// filesystem transport paths to be relative to the build context.
 func (buildDef *BuildDefinition) buildImage(store storage.Store, buildahBinary string, isBuilder bool) (err error) {
 	tag := buildDef.Tag
+
+	if storageclient.IsFilesystemTransport(tag) {
+		return buildDef.buildFilesystemImage(store, buildahBinary)
+	}
 
 	if _, err := store.Lookup(tag); err == nil && isBuilder {
 		return nil
 	}
 
+	return buildDef.runBuildah(buildahBinary, tag, !isBuilder)
+}
+
+// buildFilesystemImage builds a temporary image from ContainerfileContent and
+// pushes it to a local file/directory inside ContextDirectory using the
+// transport from the Tag (e.g. "oci-archive:", "docker-archive:", "oci:", "dir:").
+func (buildDef *BuildDefinition) buildFilesystemImage(store storage.Store, buildahBinary string) error {
+	transport, rest := splitFilesystemTransport(buildDef.Tag)
+	localPath := filesystemTransportPath(buildDef.Tag)
+	fullPath := filepath.Join(buildDef.ContextDirectory, localPath)
+
+	if _, err := os.Stat(fullPath); err == nil {
+		return nil
+	}
+
+	tmpTag := "tmp-" + uuid.New().String()
+	if err := buildDef.runBuildah(buildahBinary, tmpTag, false); err != nil {
+		return err
+	}
+	defer func() {
+		if id, err := store.Lookup(tmpTag); err == nil {
+			store.DeleteImage(id, true)
+		}
+	}()
+
+	pushDest := transport + fullPath
+	if ref := strings.TrimPrefix(rest, localPath); ref != "" {
+		pushDest += ref
+	}
+	return sh.RunV(buildahBinary, "push", tmpTag, pushDest)
+}
+
+func (buildDef *BuildDefinition) runBuildah(buildahBinary, tag string, saveStages bool) (err error) {
 	// Create a temporary file for the Containerfile content
 	tmpFile, err := os.CreateTemp("", "Containerfile-*.tmp")
 	if err != nil {
@@ -152,7 +218,7 @@ func (buildDef *BuildDefinition) buildImage(store storage.Store, buildahBinary s
 		"--tag",
 		tag,
 	}
-	if !isBuilder {
+	if saveStages {
 		args = append(args, "--save-stages", "--stage-labels")
 	}
 	args = append(args, buildDef.ContextDirectory)
@@ -199,6 +265,13 @@ func (testCase *TestCase) cleanUp(t *testing.T, store storage.Store) error {
 }
 
 func (buildDef *BuildDefinition) cleanUp(t *testing.T, store storage.Store) error {
+	if storageclient.IsFilesystemTransport(buildDef.Tag) {
+		localPath := filesystemTransportPath(buildDef.Tag)
+		fullPath := filepath.Join(buildDef.ContextDirectory, localPath)
+		t.Logf("Cleaning up filesystem transport artifact %s", fullPath)
+		os.RemoveAll(fullPath)
+		return nil
+	}
 	t.Logf("Cleaning up builder image %s", buildDef.Tag)
 	imageID, err := store.Lookup(buildDef.Tag)
 	if err != nil {
@@ -220,6 +293,9 @@ func (buildDef *BuildDefinition) cleanUp(t *testing.T, store storage.Store) erro
 // - Adding `localhost/` prefix if the tag doesn't contain a registry URL (no `/`)
 // - Adding `:latest` suffix if the tag doesn't contain a tag (no `:`)
 func normalizeTag(tag string) string {
+	if storageclient.IsSpecialBase(tag) {
+		return tag
+	}
 	if tag == "" {
 		tag = uuid.New().String()
 	}
@@ -1659,7 +1735,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[FROM special] FROM scratch as builder base": {
-			SkipTestReason: "[Priority: high] scratch is not handled in resolvePullspecs",
 			TestImage: BuildDefinition{
 				Tag: "test-from-scratch-builder",
 				ContainerfileContent: `FROM scratch AS builder
@@ -1674,29 +1749,66 @@ func TestIntegration(t *testing.T) {
 					{
 						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
 						OriginType: "intermediate",
-						Pullspec:   "scratch@sha256:dummy",
+						Pullspec:   "scratch",
 						StageAlias: "builder",
 					},
 				},
 			},
 		},
-		"[FROM special] FROM oci:archive as builder base": {
-			SkipTestReason: "[Priority: high] oci:archive transport not handled in resolvePullspecs",
+		"[FROM special] FROM oci-archive as builder base": {
 			TestImage: BuildDefinition{
 				Tag: "test-from-oci-archive-builder",
-				ContainerfileContent: `FROM oci:archive:/path/to/base.ociarchive AS builder
+				ContainerfileContent: `FROM oci-archive:test-base.ociarchive AS builder
 										COPY go_uuid.mod /content/go.mod
 
 										FROM scratch
 										COPY --from=builder /content /content`,
 				ContextDirectory: "../testdata/image_content",
 			},
+			BuilderImages: []BuildDefinition{
+				{
+					Tag: "oci-archive:test-base.ociarchive",
+					ContainerfileContent: `FROM scratch
+											COPY go2.mod /tmp/dummy
+											COPY go_syft.mod /opt/go.mod`,
+					ContextDirectory: "../testdata/image_content",
+				},
+			},
 			ExpectedResult: PackageMetadata{
 				Packages: []PackageMetadataItem{
 					{
 						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
 						OriginType: "intermediate",
-						Pullspec:   "oci:archive:/path/to/base.ociarchive",
+						Pullspec:   "oci-archive:test-base.ociarchive",
+						StageAlias: "builder",
+					},
+				},
+			},
+		},
+		"[FROM special] FROM docker:// transport as builder base": {
+			TestImage: BuildDefinition{
+				Tag: "test-from-docker-transport",
+				ContainerfileContent: `FROM docker://localhost/docker-transport-base:latest AS builder
+										COPY go_uuid.mod /content/go.mod
+
+										FROM scratch
+										COPY --from=builder /content /content`,
+				ContextDirectory: "../testdata/image_content",
+			},
+			BuilderImages: []BuildDefinition{
+				{
+					Tag: "localhost/docker-transport-base:latest",
+					ContainerfileContent: `FROM scratch
+											COPY go2.mod /base/go.mod`,
+					ContextDirectory: "../testdata/image_content",
+				},
+			},
+			ExpectedResult: PackageMetadata{
+				Packages: []PackageMetadataItem{
+					{
+						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
+						OriginType: "intermediate",
+						Pullspec:   "localhost/docker-transport-base@sha256:dummy",
 						StageAlias: "builder",
 					},
 				},

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1300,7 +1300,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[External content] External COPY in final stage": {
-			SkipTestReason: "[Priority: medium] origin_type 'external' not yet implemented - capo reports external content as 'builder'. Works otherwise.",
 			TestImage: BuildDefinition{
 				Tag: "test-external-copy-final",
 				ContainerfileContent: `FROM localhost/builder-base:latest AS builder
@@ -1833,7 +1832,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[RUN --mount] --mount from external image in builder stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
 			TestImage: BuildDefinition{
 				Tag: "test-mount-external-in-builder",
 				ContainerfileContent: `FROM localhost/mount-ext-base:latest AS builder
@@ -1870,7 +1868,7 @@ func TestIntegration(t *testing.T) {
 						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
 						OriginType: "external",
 						Pullspec:   "localhost/mount-ext-source@sha256:dummy",
-						StageAlias: "builder",
+						StageAlias: "",
 					},
 					{
 						PackageURL: "pkg:golang/golang.org/x/exp@v0.0.0-20240808152545-0cdaa3abc0fa",
@@ -1882,7 +1880,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[RUN --mount] --mount from builder stage in another builder stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
 			TestImage: BuildDefinition{
 				Tag: "test-mount-builder-stage",
 				ContainerfileContent: `FROM localhost/mount-stage-base:latest AS provider
@@ -1934,7 +1931,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[RUN --mount] --mount from external image in final stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
 			TestImage: BuildDefinition{
 				Tag: "test-mount-external-final",
 				ContainerfileContent: `FROM localhost/mount-ext-final-base:latest AS builder
@@ -1982,7 +1978,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		"[RUN --mount] --mount from builder stage in final stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
 			TestImage: BuildDefinition{
 				Tag: "test-mount-builder-final",
 				ContainerfileContent: `FROM localhost/mount-builder-final-base:latest AS builder

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 
 	"github.com/konflux-ci/capo/pkg/containerfile"
 	"github.com/konflux-ci/capo/pkg/storageclient"
@@ -180,7 +179,7 @@ func resolveBaseImages(client storageclient.Client, stages []containerfile.Stage
 	seen := make(map[string]bool)
 
 	for _, stage := range stages {
-		if stage.Base == "scratch" || strings.HasPrefix(stage.Base, "oci:archive") {
+		if storageclient.IsSpecialBase(stage.Base) {
 			continue
 		}
 

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -168,9 +168,9 @@ func TestProbe(t *testing.T) {
 				ExtraImages: []Image{},
 			},
 		},
-		"oci:archive base is excluded from base images": {
+		"oci-archive base is excluded from base images": {
 			containerfile: `FROM quay.io/rhel:9 as builder
-							FROM oci:archive:/path/to/archive
+							FROM oci-archive:/path/to/archive
 							COPY --from=builder /app /app`,
 			opts: ProbeOpts{
 				Tag:    "quay.io/image:latest",

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/konflux-ci/capo/internal/sbom"
@@ -49,7 +50,9 @@ type PackageMetadataItem struct {
 	// found multiple times as a dependency of different packages.
 	DependencyOfPURL string `json:"dependency_of_purl,omitempty"`
 
-	// Type of origin of this package, can be "builder" or "intermediate".
+	// Type of origin of this package: "builder" (from a builder stage's base image),
+	// "intermediate" (created during the build in a builder stage), or "external"
+	// (from an external image referenced via COPY --from or RUN --mount).
 	OriginType string `json:"origin_type"`
 
 	// Pullspec of the image with digest which is this package's origin.
@@ -112,19 +115,17 @@ func Scan(
 		return PackageMetadata{}, err
 	}
 
-	pkgSources, err := getPackageSources(storageClient, stages, resolvedPullspecs)
+	pkgSources, mountOnlySources, err := getPackageSources(storageClient, stages, resolvedPullspecs)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
-	for _, pkgSource := range pkgSources {
-		stagePkgItems, err := scanSource(store, pkgSource)
-		if err != nil {
-			return PackageMetadata{}, fmt.Errorf("failed to scan source %+v with error: %w", pkgSource, err)
-		}
 
-		res.Packages = append(res.Packages, stagePkgItems...)
+	packages, err := scanWithMountReattribution(stages, pkgSources, mountOnlySources, store)
+	if err != nil {
+		return PackageMetadata{}, err
 	}
 
+	res.Packages = packages
 	return res, nil
 }
 
@@ -135,18 +136,12 @@ func resolvePullspecs(storageClient storageclient.Client, stages []containerfile
 	res := make(map[string]string)
 
 	for _, stage := range stages[:len(stages)-1] {
-		if _, ok := res[stage.Base]; !ok {
-			if storageclient.IsSpecialBase(stage.Base) {
-				res[stage.Base] = stage.Base
-				continue
-			}
-
-			resolved, err := resolvePullspec(storageClient, stage.Base)
-			if err != nil {
-				return nil, err
-			}
-
-			res[stage.Base] = resolved
+		if storageclient.IsSpecialBase(stage.Base) {
+			res[stage.Base] = stage.Base
+			continue
+		}
+		if err := resolveIfNew(res, storageClient, stage.Base); err != nil {
+			return nil, err
 		}
 	}
 
@@ -155,19 +150,33 @@ func resolvePullspecs(storageClient storageclient.Client, stages []containerfile
 			if cp.Type == containerfile.CopyTypeBuilder {
 				continue
 			}
-
-			if _, ok := res[cp.From]; !ok {
-				resolved, err := resolvePullspec(storageClient, cp.From)
-				if err != nil {
-					return nil, err
-				}
-
-				res[cp.From] = resolved
+			if err := resolveIfNew(res, storageClient, cp.From); err != nil {
+				return nil, err
+			}
+		}
+		for _, mount := range stage.Mounts {
+			if mount.Type == containerfile.MountTypeBuilder {
+				continue
+			}
+			if err := resolveIfNew(res, storageClient, mount.From); err != nil {
+				return nil, err
 			}
 		}
 	}
 
 	return res, nil
+}
+
+func resolveIfNew(res map[string]string, storageClient storageclient.Client, pullspec string) error {
+	if _, ok := res[pullspec]; ok {
+		return nil
+	}
+	resolved, err := resolvePullspec(storageClient, pullspec)
+	if err != nil {
+		return err
+	}
+	res[pullspec] = resolved
+	return nil
 }
 
 // resolvePullspec uses the passed containers store to resolve a pullspec from a containerfile
@@ -195,28 +204,40 @@ func resolvePullspec(storageClient storageclient.Client, pullspec string) (strin
 	return final.String(), nil
 }
 
-// getPackageSources uses the passed containerfile stages and returns a slice
-// of packageSource structs, specifying which COPY-ied content originates from
-// which builder stage. Uses the passed storageclient.Client to get
-// OCIImageConfigs of base images to get their default workdirs for relative
-// path resolution in copy destinations.
+// getPackageSources uses the passed containerfile stages and returns two slices
+// of packageSource structs. The first slice contains sources whose findings are
+// reported in the output. The second slice contains mount-only sources: builder
+// stages referenced only via RUN --mount in non-final stages, scanned solely for
+// re-attribution of packages to their mount origin. Uses the passed storageclient.Client to get
+// OCIImageConfigs of base images to get their default workdirs for relative path
+// resolution in copy destinations.
 func getPackageSources(
 	storageClient storageclient.Client,
 	stages []containerfile.Stage,
 	resolvedPullspecs map[string]string,
-) ([]packageSource, error) {
-	res := make([]packageSource, 0)
+) ([]packageSource, []packageSource, error) {
 	aliasToStage := make(map[string]*containerfile.Stage)
-
-	// use index iteration to get consistent references to stages
-	// since we use the references as map keys
 	for i := range stages[:len(stages)-1] {
 		st := &stages[i]
 		aliasToStage[st.Alias] = st
 	}
 
-	// mapping of bases used in the containerfile to their initial working
-	// directories
+	baseToWorkdir, err := resolveBaseWorkdirs(storageClient, stages)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stageToSources, mountStageSources := collectStageSources(stages, aliasToStage, baseToWorkdir)
+
+	return buildPackageSourceSlices(stages, stageToSources, mountStageSources, resolvedPullspecs)
+}
+
+// resolveBaseWorkdirs builds a map from base image pullspec to its initial
+// working directory, used for resolving relative COPY destinations.
+func resolveBaseWorkdirs(
+	storageClient storageclient.Client,
+	stages []containerfile.Stage,
+) (map[string]string, error) {
 	baseToWorkdir := make(map[string]string)
 	for _, s := range stages {
 		if storageclient.IsSpecialBase(s.Base) {
@@ -225,76 +246,12 @@ func getPackageSources(
 
 		cfg, err := storageClient.GetImageConfig(s.Base)
 		if err != nil {
-			return []packageSource{}, fmt.Errorf("%w for %q", ErrOCIConfig, s.Base)
+			return nil, fmt.Errorf("%w for %q", ErrOCIConfig, s.Base)
 		}
 
 		baseToWorkdir[s.Base] = cfg.Config.Workdir
 	}
-
-	// The following code block reads all the builder COPY-ies in the final stage
-	// and recursively traces their content to their respective origins in previous stages.
-	// Builds a map between references to containerfile stages and the sources used in the COPY.
-	final := &stages[len(stages)-1]
-	stageToSources := make(map[*containerfile.Stage][]string)
-
-	for _, cp := range final.Copies {
-		for _, source := range cp.Sources {
-			// the copy is builder type only if there's no builder stage with alias equal to the cp.from
-			// otherwise the cp.from is a pullspec and it is an external copy
-			if _, isBuilder := aliasToStage[cp.From]; isBuilder {
-				traceSource(source, aliasToStage[cp.From], stageToSources, aliasToStage, baseToWorkdir)
-			} else {
-				external := containerfile.Stage{
-					Alias:  "",
-					Base:   cp.From,
-					Copies: []containerfile.Copy{},
-				}
-
-				stageToSources[&external] = append(stageToSources[&external], source)
-			}
-		}
-	}
-
-	// construct builder package sources
-	for i := range stages[:len(stages)-1] {
-		stage := &stages[i]
-
-		digestPullspec, ok := resolvedPullspecs[stage.Base]
-		if !ok {
-			return []packageSource{},
-				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Base)
-		}
-
-		res = append(res, packageSource{
-			alias:      stage.Alias,
-			pullspec:   stage.Base,
-			digestBase: digestPullspec,
-			sources:    stageToSources[stage],
-		})
-
-		// the processed stage must be deleted from stageToSources so it only
-		// contains "external" stages after builder stages are constructed.
-		// These are then processed in the next code block below.
-		delete(stageToSources, stage)
-	}
-
-	// construct external package sources
-	for stage, sources := range stageToSources {
-		digestPullspec, ok := resolvedPullspecs[stage.Base]
-		if !ok {
-			return []packageSource{},
-				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Base)
-		}
-
-		res = append(res, packageSource{
-			alias:      stage.Alias,
-			pullspec:   stage.Base,
-			digestBase: digestPullspec,
-			sources:    sources,
-		})
-	}
-
-	return res, nil
+	return baseToWorkdir, nil
 }
 
 // traceSource takes a source path and the stage it was found in and recursively
@@ -351,6 +308,24 @@ func traceSource(
 	if coversMultipleFiles || !foundAncestor {
 		acc[currStage] = append(acc[currStage], source)
 	}
+}
+
+// mergeStageSources merges mount-derived source paths into direct source paths,
+// deduplicating entries. Returns nil if directSources is nil and there are no
+// mount sources to merge.
+func mergeStageSources(directSources, mountSources []string) []string {
+	if mountSources == nil {
+		return directSources
+	}
+	if directSources == nil {
+		return nil
+	}
+	for _, s := range mountSources {
+		if !slices.Contains(directSources, s) {
+			directSources = append(directSources, s)
+		}
+	}
+	return directSources
 }
 
 // scanSource uses the passed initialized storage.Store struct to syft scan content
@@ -412,34 +387,172 @@ func scanSource(
 
 // getPackageMetadata uses the passed packageSource and its builder and intermediate
 // packages to return a slice of PackageMetadataItem structs to signify package origins.
+// External sources (alias == "") use OriginType "external" for all packages.
 func getPackageMetadata(
 	pkgSource packageSource,
 	builderPkgs []sbom.SyftPackage,
 	intermediatePkgs []sbom.SyftPackage,
 ) []PackageMetadataItem {
+	isExternal := pkgSource.alias == ""
 	res := make([]PackageMetadataItem, 0, len(builderPkgs)+len(intermediatePkgs))
 
 	for _, bpkg := range builderPkgs {
+		originType := "builder"
+		if isExternal {
+			originType = "external"
+		}
 		res = append(res, PackageMetadataItem{
 			Pullspec:         pkgSource.digestBase,
 			StageAlias:       pkgSource.alias,
 			PackageURL:       bpkg.PURL,
 			DependencyOfPURL: bpkg.DependencyOfPURL,
 			Checksums:        bpkg.Checksums,
-			OriginType:       "builder",
+			OriginType:       originType,
 		})
 	}
 
 	for _, ipkg := range intermediatePkgs {
+		originType := "intermediate"
+		if isExternal {
+			originType = "external"
+		}
 		res = append(res, PackageMetadataItem{
 			Pullspec:         pkgSource.digestBase,
 			StageAlias:       pkgSource.alias,
 			PackageURL:       ipkg.PURL,
 			DependencyOfPURL: ipkg.DependencyOfPURL,
 			Checksums:        ipkg.Checksums,
-			OriginType:       "intermediate",
+			OriginType:       originType,
 		})
 	}
 
 	return res
+}
+
+// mountConsumer identifies a specific package within a consuming stage,
+// used to look up whether it came from a mounted source.
+type mountConsumer struct {
+	stageAlias string
+	packageURL string
+}
+
+// mountOrigin holds the mount source's identity for a package. When a stage
+// uses RUN --mount and we find the same package in both the stage's
+// intermediate layer and the mount source, this struct tells us where the
+// package actually came from so we can correct its reported origin.
+type mountOrigin struct {
+	digestBase         string
+	providerStageAlias string
+	originType         string
+	// When true, the mount source is already in the reportable results,
+	// so we deduplicate (drop) the consuming stage's copy. When false,
+	// we overwrite the consuming stage's origin fields with the mount source's.
+	reported bool
+}
+
+// scanWithMountReattribution scans all package sources and applies mount
+// re-attribution. For each stage with RUN --mount, intermediate packages
+// matching a mount source are either re-attributed (origin details overwritten)
+// or deduplicated (dropped), depending on whether the mount source is already
+// in pkgSources (directly reported) or only in mountOnlySources.
+func scanWithMountReattribution(
+	stages []containerfile.Stage,
+	pkgSources []packageSource,
+	mountOnlySources []packageSource,
+	store storage.Store,
+) ([]PackageMetadataItem, error) {
+	// Map mount reference (stage alias or pullspec) to the aliases of
+	// stages that consume it via RUN --mount.
+	consumers := make(map[string][]string)
+	for _, stage := range stages {
+		for _, mount := range stage.Mounts {
+			consumers[mount.From] = append(consumers[mount.From], stage.Alias)
+		}
+	}
+
+	origins := make(map[mountConsumer]mountOrigin)
+
+	// Scan mount-only sources and register their packages (reported=false).
+	for _, src := range mountOnlySources {
+		items, err := scanSource(store, src)
+		if err != nil {
+			return nil, err
+		}
+		registerMountPackages(origins, consumers, src, items, false)
+	}
+
+	// Scan reportable sources, register their packages for mount lookups
+	// (reported=true), and collect all scanned items per source.
+	sourcesItems := make([][]PackageMetadataItem, 0, len(pkgSources))
+	for _, src := range pkgSources {
+		items, err := scanSource(store, src)
+		if err != nil {
+			return nil, err
+		}
+		registerMountPackages(origins, consumers, src, items, true)
+		sourcesItems = append(sourcesItems, items)
+	}
+
+	// Apply re-attribution: for each intermediate package that matches a
+	// mount origin, either overwrite its origin fields or drop it.
+	var packages []PackageMetadataItem
+	for i, src := range pkgSources {
+		for _, item := range sourcesItems[i] {
+			if item.OriginType != "intermediate" {
+				packages = append(packages, item)
+				continue
+			}
+			origin, fromMount := origins[mountConsumer{stageAlias: src.alias, packageURL: item.PackageURL}]
+			if !fromMount {
+				packages = append(packages, item)
+				continue
+			}
+			if origin.reported {
+				log.Printf("Deduplicating intermediate package %s from stage %q (mount source already reported).",
+					item.PackageURL, src.alias)
+				continue
+			}
+			log.Printf("Re-attributing intermediate package %s from stage %q to mount source %q.",
+				item.PackageURL, src.alias, origin.providerStageAlias)
+			item.Pullspec = origin.digestBase
+			item.StageAlias = origin.providerStageAlias
+			item.OriginType = origin.originType
+			packages = append(packages, item)
+		}
+	}
+
+	return packages, nil
+}
+
+// registerMountPackages populates the origins map for a single scan result
+// that may be referenced as a mount source. For each package in the result,
+// it is registered under every consuming stage that mounts from this source.
+func registerMountPackages(
+	origins map[mountConsumer]mountOrigin,
+	consumers map[string][]string,
+	source packageSource,
+	items []PackageMetadataItem,
+	reported bool,
+) {
+	refKey := source.alias
+	if refKey == "" {
+		refKey = source.pullspec
+	}
+	stageAliases := consumers[refKey]
+	if len(stageAliases) == 0 {
+		return
+	}
+	for _, stageAlias := range stageAliases {
+		for _, pkg := range items {
+			key := mountConsumer{stageAlias: stageAlias, packageURL: pkg.PackageURL}
+			if _, exists := origins[key]; !exists {
+				origins[key] = mountOrigin{
+					digestBase:         source.digestBase,
+					providerStageAlias: source.alias,
+					originType:         pkg.OriginType,
+					reported:           reported,
+				}
+			}
+		}
+	}
 }

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -136,6 +136,11 @@ func resolvePullspecs(storageClient storageclient.Client, stages []containerfile
 
 	for _, stage := range stages[:len(stages)-1] {
 		if _, ok := res[stage.Base]; !ok {
+			if storageclient.IsSpecialBase(stage.Base) {
+				res[stage.Base] = stage.Base
+				continue
+			}
+
 			resolved, err := resolvePullspec(storageClient, stage.Base)
 			if err != nil {
 				return nil, err
@@ -166,8 +171,11 @@ func resolvePullspecs(storageClient storageclient.Client, stages []containerfile
 }
 
 // resolvePullspec uses the passed containers store to resolve a pullspec from a containerfile
-// into a pullspec with digest without tag.
+// into a canonical pullspec with digest without tag. Transport prefixes (e.g. "docker://")
+// are stripped and not included in the result.
 func resolvePullspec(storageClient storageclient.Client, pullspec string) (string, error) {
+	pullspec = storageclient.StripTransport(pullspec)
+
 	digest, err := storageClient.ResolveDigest(pullspec)
 	if err != nil {
 		return "", fmt.Errorf("%w %q: %w", ErrPullspecResolve, pullspec, err)
@@ -211,7 +219,7 @@ func getPackageSources(
 	// directories
 	baseToWorkdir := make(map[string]string)
 	for _, s := range stages {
-		if s.Base == "scratch" || s.Base == "oci:archive" {
+		if storageclient.IsSpecialBase(s.Base) {
 			continue
 		}
 

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -34,6 +34,7 @@ func TestGetPackageSources(t *testing.T) {
 		resolvedPullspecs map[string]string
 		configs           map[string]storageclient.OCIImageConfig
 		expected          []packageSource
+		expectedMountOnly []packageSource
 	}{
 		"only external copy in final": {
 			stages: []containerfile.Stage{
@@ -544,7 +545,6 @@ func TestGetPackageSources(t *testing.T) {
 					Alias: "builder2",
 					Base:  "docker.io/library/node:latest",
 					Copies: []containerfile.Copy{
-						// explicit workdir takes precedence over base image workdir (/var/data)
 						{
 							From:        "builder1",
 							Sources:     []string{"/usr/bin/app"},
@@ -552,7 +552,6 @@ func TestGetPackageSources(t *testing.T) {
 							Type:        containerfile.CopyTypeBuilder,
 							Workdir:     "/usr/local",
 						},
-						// base image workdir resolves relative destination
 						{
 							From:        "builder1",
 							Sources:     []string{"/usr/bin/tool"},
@@ -614,14 +613,12 @@ func TestGetPackageSources(t *testing.T) {
 					Alias: "builder2",
 					Base:  "docker.io/library/alpine:latest",
 					Copies: []containerfile.Copy{
-						// absolute destination (no workdir resolution)
 						{
 							From:        "builder1",
 							Sources:     []string{"/usr/bin/cli"},
 							Destination: "/usr/local/bin/cli",
 							Type:        containerfile.CopyTypeBuilder,
 						},
-						// parent directory navigation
 						{
 							From:        "builder1",
 							Sources:     []string{"/etc/app.conf"},
@@ -629,7 +626,6 @@ func TestGetPackageSources(t *testing.T) {
 							Type:        containerfile.CopyTypeBuilder,
 							Workdir:     "/app/subdir",
 						},
-						// dot destination resolves to workdir
 						{
 							From:        "builder1",
 							Sources:     []string{"/src/app"},
@@ -637,7 +633,6 @@ func TestGetPackageSources(t *testing.T) {
 							Type:        containerfile.CopyTypeBuilder,
 							Workdir:     "/opt",
 						},
-						// workdir switching within stage
 						{
 							From:        "builder1",
 							Sources:     []string{"/etc/defaults.conf"},
@@ -871,6 +866,231 @@ func TestGetPackageSources(t *testing.T) {
 				},
 			},
 		},
+		"external mount in final stage": {
+			stages: []containerfile.Stage{
+				{
+					Alias:  "builder",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
+				},
+				{
+					Alias: containerfile.FinalStage,
+					Base:  "scratch",
+					Copies: []containerfile.Copy{
+						{
+							From:        "builder",
+							Sources:     []string{"/opt/"},
+							Destination: "/opt/",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+					Mounts: []containerfile.Mount{
+						{
+							From:   "quay.io/tools:1",
+							Type:   containerfile.MountTypeExternal,
+							Source: "/",
+						},
+					},
+				},
+			},
+			resolvedPullspecs: map[string]string{
+				"docker.io/library/fedora:latest": "docker.io/library/fedora@sha256:abc123",
+				"quay.io/tools:1":                 "quay.io/tools@sha256:def456",
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expected: []packageSource{
+				{
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:abc123",
+					sources:    []string{"/opt/"},
+				},
+				{
+					alias:      "",
+					pullspec:   "quay.io/tools:1",
+					digestBase: "quay.io/tools@sha256:def456",
+					sources:    []string{"/"},
+				},
+			},
+		},
+		"builder mount in final stage broadens sources": {
+			stages: []containerfile.Stage{
+				{
+					Alias:  "builder",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
+				},
+				{
+					Alias:  containerfile.FinalStage,
+					Base:   "scratch",
+					Copies: []containerfile.Copy{},
+					Mounts: []containerfile.Mount{
+						{
+							From:   "builder",
+							Type:   containerfile.MountTypeBuilder,
+							Source: "/",
+						},
+					},
+				},
+			},
+			resolvedPullspecs: map[string]string{
+				"docker.io/library/fedora:latest": "docker.io/library/fedora@sha256:abc123",
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expected: []packageSource{
+				{
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:abc123",
+					sources:    []string{"/"},
+				},
+			},
+		},
+		"builder mount in builder stage": {
+			stages: []containerfile.Stage{
+				{
+					Alias:  "provider",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
+				},
+				{
+					Alias:  "consumer",
+					Base:   "docker.io/alpine/helm:latest",
+					Copies: []containerfile.Copy{},
+					Mounts: []containerfile.Mount{
+						{
+							From:   "provider",
+							Type:   containerfile.MountTypeBuilder,
+							Source: "/",
+						},
+					},
+				},
+				{
+					Alias: containerfile.FinalStage,
+					Base:  "scratch",
+					Copies: []containerfile.Copy{
+						{
+							From:        "consumer",
+							Sources:     []string{"/opt/"},
+							Destination: "/opt/",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			resolvedPullspecs: map[string]string{
+				"docker.io/library/fedora:latest": "docker.io/library/fedora@sha256:abc123",
+				"docker.io/alpine/helm:latest":    "docker.io/alpine/helm@sha256:def456",
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
+			},
+			expected: []packageSource{
+				{
+					alias:      "consumer",
+					pullspec:   "docker.io/alpine/helm:latest",
+					digestBase: "docker.io/alpine/helm@sha256:def456",
+					sources:    []string{"/opt/"},
+				},
+			},
+			expectedMountOnly: []packageSource{
+				{
+					alias:      "provider",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:abc123",
+					sources:    []string{"/"},
+				},
+			},
+		},
+		"external mount in builder stage": {
+			stages: []containerfile.Stage{
+				{
+					Alias:  "builder",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
+					Mounts: []containerfile.Mount{
+						{
+							From:   "quay.io/tools:1",
+							Type:   containerfile.MountTypeExternal,
+							Source: "/",
+						},
+					},
+				},
+				{
+					Alias: containerfile.FinalStage,
+					Base:  "scratch",
+					Copies: []containerfile.Copy{
+						{
+							From:        "builder",
+							Sources:     []string{"/opt/"},
+							Destination: "/opt/",
+							Type:        containerfile.CopyTypeBuilder,
+						},
+					},
+				},
+			},
+			resolvedPullspecs: map[string]string{
+				"docker.io/library/fedora:latest": "docker.io/library/fedora@sha256:abc123",
+				"quay.io/tools:1":                 "quay.io/tools@sha256:def456",
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expected: []packageSource{
+				{
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:abc123",
+					sources:    []string{"/opt/"},
+				},
+				{
+					alias:      "",
+					pullspec:   "quay.io/tools:1",
+					digestBase: "quay.io/tools@sha256:def456",
+					sources:    []string{"/"},
+				},
+			},
+		},
+		"mount with specific source narrows scan path": {
+			stages: []containerfile.Stage{
+				{
+					Alias:  "builder",
+					Base:   "docker.io/library/fedora:latest",
+					Copies: []containerfile.Copy{},
+				},
+				{
+					Alias:  containerfile.FinalStage,
+					Base:   "scratch",
+					Copies: []containerfile.Copy{},
+					Mounts: []containerfile.Mount{
+						{
+							From:   "builder",
+							Type:   containerfile.MountTypeBuilder,
+							Source: "/usr/lib",
+						},
+					},
+				},
+			},
+			resolvedPullspecs: map[string]string{
+				"docker.io/library/fedora:latest": "docker.io/library/fedora@sha256:abc123",
+			},
+			configs: map[string]storageclient.OCIImageConfig{
+				"docker.io/library/fedora:latest": configWithWorkdir("/"),
+			},
+			expected: []packageSource{
+				{
+					alias:      "builder",
+					pullspec:   "docker.io/library/fedora:latest",
+					digestBase: "docker.io/library/fedora@sha256:abc123",
+					sources:    []string{"/usr/lib"},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -879,19 +1099,27 @@ func TestGetPackageSources(t *testing.T) {
 
 			mockClient := storageclient.NewMockClient(map[string]digest.Digest{}, test.configs)
 
-			actual, err := getPackageSources(mockClient, test.stages, test.resolvedPullspecs)
+			actual, actualMountOnly, err := getPackageSources(mockClient, test.stages, test.resolvedPullspecs)
 			if err != nil {
 				t.Fatalf("getPackageSources returned error: %v", err)
 			}
 
-			diff := cmp.Diff(
-				test.expected, actual,
+			cmpOpts := cmp.Options{
 				cmp.AllowUnexported(packageSource{}),
-				cmpopts.SortSlices(func(a, b packageSource) bool { return a.alias < b.alias }),
+				cmpopts.SortSlices(func(a, b packageSource) bool {
+					if a.alias != b.alias {
+						return a.alias < b.alias
+					}
+					return a.pullspec < b.pullspec
+				}),
 				cmpopts.EquateEmpty(),
-			)
-			if diff != "" {
+			}
+
+			if diff := cmp.Diff(test.expected, actual, cmpOpts...); diff != "" {
 				t.Errorf("getPackageSources() mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.expectedMountOnly, actualMountOnly, cmpOpts...); diff != "" {
+				t.Errorf("getPackageSources() mountOnly mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -924,7 +1152,7 @@ func TestGetPackageSourcesError(t *testing.T) {
 
 			mockClient := testutils.NewTStorageClient(map[string]digest.Digest{}, test.configs)
 
-			_, err := getPackageSources(mockClient, test.stages, test.resolvedPullspecs)
+			_, _, err := getPackageSources(mockClient, test.stages, test.resolvedPullspecs)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/pkg/storageclient/storageclient.go
+++ b/pkg/storageclient/storageclient.go
@@ -13,6 +13,59 @@ import (
 	"go.podman.io/storage/pkg/reexec"
 )
 
+// Transports that prefix a docker-reference resolvable via store.Lookup.
+// These are stripped before lookup and re-added to the resolved result.
+// See https://github.com/containers/image/blob/main/docs/containers-transports.5.md
+var strippableTransports = []string{
+	"docker://",
+	"docker-daemon:",
+}
+
+// Filesystem-based transports that reference local paths rather than images
+// in containers/storage. These cannot be resolved via store.Lookup.
+// See https://github.com/containers/image/blob/main/docs/containers-transports.5.md
+var filesystemTransports = []string{
+	"oci-archive:",
+	"docker-archive:",
+	"oci:",
+	"dir:",
+}
+
+// StripTransport removes known resolvable transport prefixes (e.g.
+// "docker://", "docker-daemon:") from a pullspec so it can be used with
+// store.Lookup and reference.ParseNamed, which only understand plain image
+// references.
+// See https://github.com/containers/image/blob/main/docs/containers-transports.5.md
+func StripTransport(pullspec string) string {
+	for _, prefix := range strippableTransports {
+		if after, ok := strings.CutPrefix(pullspec, prefix); ok {
+			return after
+		}
+	}
+	return pullspec
+}
+
+// IsFilesystemTransport checks if the pullspec uses a filesystem-based
+// transport (oci-archive:, docker-archive:, oci:, dir:) that references a
+// local path rather than an image in containers/storage.
+// See https://github.com/containers/image/blob/main/docs/containers-transports.5.md
+func IsFilesystemTransport(base string) bool {
+	for _, prefix := range filesystemTransports {
+		if strings.HasPrefix(base, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSpecialBase checks if the base pullspec is a special base that cannot be
+// resolved via store.Lookup. This includes scratch and all filesystem-based
+// transports (oci-archive:, docker-archive:, oci:, dir:).
+// See https://github.com/containers/image/blob/main/docs/containers-transports.5.md
+func IsSpecialBase(base string) bool {
+	return base == "scratch" || IsFilesystemTransport(base)
+}
+
 // Wrapper for the application/vnd.oci.image.config.v1+json media type.
 // https://github.com/opencontainers/image-spec/blob/main/config.md
 type OCIImageConfig struct {
@@ -75,9 +128,10 @@ func NewBuildahClient(store storage.Store) Client {
 }
 
 // ResolveDigest looks up the given pullspec in the local storage and returns
-// its content digest in the form "sha256:<hex>".
+// its content digest in the form "sha256:<hex>". Transport prefixes (e.g.
+// "docker://") are stripped before the lookup.
 func (c *BuildahClient) ResolveDigest(pullspec string) (digest.Digest, error) {
-	id, err := c.store.Lookup(pullspec)
+	id, err := c.store.Lookup(StripTransport(pullspec))
 	if err != nil {
 		return "", fmt.Errorf("%w %q: %w", ErrPullspecResolve, pullspec, err)
 	}
@@ -93,7 +147,7 @@ func (c *BuildahClient) ResolveDigest(pullspec string) (digest.Digest, error) {
 // Get an OCIImageConfig struct for the passed pullspec via buildah's container
 // storage.
 func (c *BuildahClient) GetImageConfig(pullspec string) (OCIImageConfig, error) {
-	imgId, err := c.store.Lookup(pullspec)
+	imgId, err := c.store.Lookup(StripTransport(pullspec))
 	if err != nil {
 		return OCIImageConfig{}, fmt.Errorf("%w %s: %w", ErrOCIImageConfig, pullspec, err)
 	}

--- a/pkg/storageclient/storageclient_test.go
+++ b/pkg/storageclient/storageclient_test.go
@@ -1,0 +1,105 @@
+//go:build unit
+
+package storageclient
+
+import (
+	"testing"
+)
+
+func TestIsSpecialBase(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		base string
+		want bool
+	}{
+		"scratch": {
+			base: "scratch",
+			want: true,
+		},
+		"oci-archive with reference": {
+			base: "oci-archive:base.ociarchive:latest",
+			want: true,
+		},
+		"oci-archive without reference": {
+			base: "oci-archive:path/to/file",
+			want: true,
+		},
+		"docker-archive with reference": {
+			base: "docker-archive:/tmp/image.tar:latest",
+			want: true,
+		},
+		"oci layout with reference": {
+			base: "oci:/tmp/oci-layout:latest",
+			want: true,
+		},
+		"dir transport": {
+			base: "dir:/tmp/some-dir",
+			want: true,
+		},
+		"normal pullspec": {
+			base: "docker.io/library/alpine:latest",
+			want: false,
+		},
+		"case sensitive - Scratch": {
+			base: "Scratch",
+			want: false,
+		},
+		"prefix collision - scratchy": {
+			base: "scratchy",
+			want: false,
+		},
+		"oci-archive not at prefix": {
+			base: "my-oci-archive:foo",
+			want: false,
+		},
+		"normal pullspec with colon": {
+			base: "quay.io/rhel:9",
+			want: false,
+		},
+		"docker:// is not special": {
+			base: "docker://docker.io/library/alpine:latest",
+			want: false,
+		},
+		"docker-daemon: is not special": {
+			base: "docker-daemon:alpine:latest",
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := IsSpecialBase(tc.base)
+			if got != tc.want {
+				t.Errorf("IsSpecialBase(%q) = %v, want %v", tc.base, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripTransport(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"docker:// prefix stripped": {
+			input: "docker://docker.io/library/alpine:latest",
+			want:  "docker.io/library/alpine:latest",
+		},
+		"docker-daemon: with registry": {
+			input: "docker-daemon:docker.io/library/nginx:latest",
+			want:  "docker.io/library/nginx:latest",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := StripTransport(tc.input)
+			if got != tc.want {
+				t.Errorf("StripTransport(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/trackcontent.go
+++ b/pkg/trackcontent.go
@@ -1,0 +1,147 @@
+/*
+The trackcontent package traces content origins from COPY and RUN --mount
+instructions across stages in a containerfile.
+*/
+package capo
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/konflux-ci/capo/pkg/containerfile"
+)
+
+// collectStageSources traces content origins from copies and mounts across stages.
+// Returns stageToSources (stages with content reaching the final image) and
+// mountStageSources (stages referenced only via mounts in non-final stages).
+func collectStageSources(
+	stages []containerfile.Stage,
+	aliasToStage map[string]*containerfile.Stage,
+	baseToWorkdir map[string]string,
+) (stageToSources, mountStageSources map[*containerfile.Stage][]string) {
+	stageToSources = make(map[*containerfile.Stage][]string)
+	mountStageSources = make(map[*containerfile.Stage][]string)
+	final := &stages[len(stages)-1]
+
+	traceCopySources(final.Copies, aliasToStage, baseToWorkdir, stageToSources)
+
+	for _, mount := range final.Mounts {
+		collectMountSource(mount, aliasToStage, stageToSources, stageToSources)
+	}
+
+	for i := range stages[:len(stages)-1] {
+		for _, mount := range stages[i].Mounts {
+			collectMountSource(mount, aliasToStage, mountStageSources, stageToSources)
+		}
+	}
+
+	return stageToSources, mountStageSources
+}
+
+// traceCopySources traces content origins for all copies in the final stage.
+// Builder copies are recursively traced via traceSource; external copies create
+// synthetic stages in the accumulator.
+func traceCopySources(
+	copies []containerfile.Copy,
+	aliasToStage map[string]*containerfile.Stage,
+	baseToWorkdir map[string]string,
+	stageToSources map[*containerfile.Stage][]string,
+) {
+	for _, cp := range copies {
+		for _, source := range cp.Sources {
+			if _, isBuilder := aliasToStage[cp.From]; isBuilder {
+				traceSource(source, aliasToStage[cp.From], stageToSources, aliasToStage, baseToWorkdir)
+				continue
+			}
+			external := &containerfile.Stage{
+				Alias:  "",
+				Base:   cp.From,
+				Copies: []containerfile.Copy{},
+			}
+			stageToSources[external] = append(stageToSources[external], source)
+		}
+	}
+}
+
+// collectMountSource adds a mount's source path to the appropriate target map.
+// Builder mounts add to builderTarget, external mounts create a synthetic stage
+// in externalTarget. Source paths are deduplicated per stage.
+func collectMountSource(
+	mount containerfile.Mount,
+	aliasToStage map[string]*containerfile.Stage,
+	builderTarget map[*containerfile.Stage][]string,
+	externalTarget map[*containerfile.Stage][]string,
+) {
+	if mount.Type == containerfile.MountTypeBuilder {
+		if stage, ok := aliasToStage[mount.From]; ok {
+			if !slices.Contains(builderTarget[stage], mount.Source) {
+				builderTarget[stage] = append(builderTarget[stage], mount.Source)
+			}
+		}
+		return
+	}
+	external := &containerfile.Stage{
+		Alias:  "",
+		Base:   mount.From,
+		Copies: []containerfile.Copy{},
+	}
+	externalTarget[external] = append(externalTarget[external], mount.Source)
+}
+
+// buildPackageSourceSlices constructs the reportable and mount-only packageSource
+// slices from the collected stage-to-sources maps.
+func buildPackageSourceSlices(
+	stages []containerfile.Stage,
+	stageToSources map[*containerfile.Stage][]string,
+	mountStageSources map[*containerfile.Stage][]string,
+	resolvedPullspecs map[string]string,
+) (reportable []packageSource, mountOnly []packageSource, err error) {
+	reportable = make([]packageSource, 0, len(stages))
+
+	for i := range stages[:len(stages)-1] {
+		stage := &stages[i]
+
+		digestPullspec, ok := resolvedPullspecs[stage.Base]
+		if !ok {
+			return nil, nil,
+				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Base)
+		}
+
+		sources := mergeStageSources(stageToSources[stage], mountStageSources[stage])
+		if sources == nil && mountStageSources[stage] != nil {
+			mountOnly = append(mountOnly, packageSource{
+				alias:      stage.Alias,
+				pullspec:   stage.Base,
+				digestBase: digestPullspec,
+				sources:    mountStageSources[stage],
+			})
+			continue
+		}
+
+		reportable = append(reportable, packageSource{
+			alias:      stage.Alias,
+			pullspec:   stage.Base,
+			digestBase: digestPullspec,
+			sources:    sources,
+		})
+
+		delete(stageToSources, stage)
+	}
+
+	for stage, sources := range stageToSources {
+		digestPullspec, ok := resolvedPullspecs[stage.Base]
+		if !ok {
+			return nil, nil,
+				fmt.Errorf("%w %q: could not find resolved pullspec", ErrPullspecResolve, stage.Base)
+		}
+		reportable = append(reportable, packageSource{
+			alias:      stage.Alias,
+			pullspec:   stage.Base,
+			digestBase: digestPullspec,
+			sources:    sources,
+		})
+	}
+
+	return reportable, mountOnly, nil
+}
+


### PR DESCRIPTION
* the content is attributed to mounted image iff:
  * the scan of the mounted stage directory contains the package &&
  * the scan of the consumer intermediate stage (the one where the RUN --mount was used) contains the same package
* high-level mechanism proposed by me, code assisted by AI (with many iterations)


Assisted-by: Claude-4.6-Cursor