### PR TITLE
chore(ISV-7208): add dependabot and conventional commit enforcement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(actions): "
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(go): "

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,31 @@
+name: PR
+
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  gitlint:
+    name: Run gitlint checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Install gitlint
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install gitlint
+
+      - name: Run gitlint check
+        run: |
+          source venv/bin/activate
+          RAW_BASE_REF="${{ github.base_ref || github.event.merge_group.base_ref }}"
+          BASE_REF="${RAW_BASE_REF#refs/heads/}"
+          echo "Base ref: $BASE_REF"
+          git fetch origin "$BASE_REF"
+          gitlint --commits "origin/$BASE_REF"..HEAD

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,17 @@
+[general]
+contrib=contrib-title-conventional-commits
+ignore=T5
+
+[title-max-length]
+line-length=72
+
+[body-max-line-length]
+line-length=88
+
+[body-first-line-empty]
+
+[contrib-title-conventional-commits]
+
+[ignore-by-author-name]
+regex=(.*)\[bot\](.*)
+ignore=T1,B1

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install
 mage lint
 ```
 
+### Commit Messages
+
+This project enforces
+[Conventional Commits](https://www.conventionalcommits.org/) via
+[gitlint](https://jorisroovers.com/gitlint/) in CI. Commits must follow:
+
+```
+type(scope): description
+```
+
+- **Allowed types:** `chore`, `docs`, `feat`, `fix`, `refactor`, `style`, `test`, `revert`
+- **Scope** is optional (e.g. `fix(ISV-1234): resolve layer matching`)
+- **Title** max 72 characters, **body** max 88 characters per line
+
 ### Integration Tests
 
 Integration tests require buildah with `--save-stages --stage-labels` support

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ type(scope): description
 - **Scope** is optional (e.g. `fix(ISV-1234): resolve layer matching`)
 - **Title** max 72 characters, **body** max 88 characters per line
 
+To validate your commits locally before pushing:
+```sh
+pip install gitlint
+gitlint --commits origin/main..HEAD
+```
+
 ### Integration Tests
 
 Integration tests require buildah with `--save-stages --stage-labels` support


### PR DESCRIPTION
Add dependency update automation via Dependabot (gomod + github-actions, weekly on Monday) and conventional commit enforcement via gitlint in CI. Configuration was inspired by konflux-ci/release-service. Document commit message rules in README Contributing section.