### PR TITLE
feat(ISV-7293): support custom logging in capo as a library

### DIFF
--- a/cmd/capo/main.go
+++ b/cmd/capo/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"runtime/debug"
 
@@ -132,7 +133,16 @@ func main() {
 	}
 	log.Printf("Parsed stages: %+v", stages)
 
-	pkgMetadata, err := capo.Scan(stages)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	scanner, err := capo.NewScanner(capo.WithLogger(logger))
+	if err != nil {
+		log.Fatalf("Failed to create scanner: %+v", err)
+	}
+
+	pkgMetadata, err := scanner.Scan(stages)
 	if err != nil {
 		log.Fatalf("Failed to scan stages: %+v", err)
 	}

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -37,9 +36,7 @@ var ErrMissingStageLabel = errors.New("intermediate image is missing io.buildah.
 //
 // Uses buildah stage labels (io.buildah.stage.name) to identify intermediate
 // image for each stage.
-func getContent(
-	store storage.Store,
-	client storageclient.Client,
+func (s *Scanner) getContent(
 	pkgSource packageSource,
 	builderContentPath string,
 	intermediateContentPath string,
@@ -49,20 +46,18 @@ func getContent(
 
 	if !isSpecialBase {
 		// Special bases are not pullable or resolvable with Lookup
-		imgId, err := store.Lookup(storageclient.StripTransport(pkgSource.pullspec))
+		imgId, err := s.store.Lookup(storageclient.StripTransport(pkgSource.pullspec))
 		if err != nil {
 			return fmt.Errorf("%w: %q", ErrImageNotFound, pkgSource.pullspec)
 		}
-		builderImage, err = store.Image(imgId)
+		builderImage, err = s.store.Image(imgId)
 		if err != nil {
 			return fmt.Errorf("%w: %q", ErrImageNotFound, pkgSource.pullspec)
 		}
 	}
 
 	// Special bases will have builderImage set as nil
-	intermediate, err := getIntermediateContent(
-		store,
-		client,
+	intermediate, err := s.getIntermediateContent(
 		builderImage,
 		pkgSource.alias,
 		pkgSource.sources,
@@ -72,25 +67,25 @@ func getContent(
 	if err != nil {
 		return err
 	}
-	logContent("intermediate", intermediate, pkgSource.pullspec)
+	s.logContent("intermediate", intermediate, pkgSource.pullspec)
 
 	if !isSpecialBase {
 		// Only standard bases have builder content. All content in special bases is treated as intermediate.
-		builderContent, err := getImageContent(store, builderImage, pkgSource.sources, builderContentPath)
+		builderContent, err := s.getImageContent(builderImage, pkgSource.sources, builderContentPath)
 		if err != nil {
 			return err
 		}
-		logContent("builder", builderContent, pkgSource.pullspec)
+		s.logContent("builder", builderContent, pkgSource.pullspec)
 	}
 
 	return nil
 }
 
-func logContent(kind string, content []string, pullspec string) {
+func (s *Scanner) logContent(kind string, content []string, pullspec string) {
 	if len(content) == 0 {
-		log.Printf("Found no %s content for %s.", kind, pullspec)
+		s.logger.Debug("found no content", "kind", kind, "pullspec", pullspec)
 	} else {
-		log.Printf("Included %s content %+v for %s.", kind, content, pullspec)
+		s.logger.Debug("included content", "kind", kind, "content", content, "pullspec", pullspec)
 	}
 }
 
@@ -134,19 +129,18 @@ func includes(sources []string, path string) bool {
 	return false
 }
 
-func getImageContent(
-	store storage.Store,
+func (s *Scanner) getImageContent(
 	image *storage.Image,
 	sources []string,
 	contentPath string,
 ) (included []string, err error) {
-	mountPath, err := store.MountImage(image.ID, []string{}, "")
+	mountPath, err := s.store.MountImage(image.ID, []string{}, "")
 	if err != nil {
 		return included, fmt.Errorf("%w: %w", ErrImageMount, err)
 	}
 
 	defer func() {
-		if _, unmountErr := store.UnmountImage(image.ID, false); unmountErr != nil {
+		if _, unmountErr := s.store.UnmountImage(image.ID, false); unmountErr != nil {
 			err = fmt.Errorf("%w: failed to unmount image: %w", ErrStorage, unmountErr)
 		}
 	}()
@@ -228,16 +222,14 @@ func copyFile(src string, dest string) (err error) {
 // the intermediate image and reads all matching content. Filesystem-transport
 // bases are local files with non-pullable identifiers, so all their content
 // is treated uniformly as intermediate.
-func getIntermediateContent(
-	store storage.Store,
-	client storageclient.Client,
+func (s *Scanner) getIntermediateContent(
 	builderImage *storage.Image,
 	stageAlias string,
 	sources []string,
 	path string,
 ) ([]string, error) {
 	// Find intermediate image using buildah stage labels
-	intermediateImage, found, err := findIntermediateImage(store, client, stageAlias)
+	intermediateImage, found, err := s.findIntermediateImage(stageAlias)
 	if err != nil {
 		return []string{}, fmt.Errorf("%w: failed to find intermediate image: %w", ErrStorage, err)
 	}
@@ -248,20 +240,20 @@ func getIntermediateContent(
 
 	if builderImage == nil {
 		// Scratch or unresolvable (special) bases
-		return getImageContent(store, intermediateImage, sources, path)
+		return s.getImageContent(intermediateImage, sources, path)
 	}
 
-	builderLayer, err := store.Layer(builderImage.TopLayer)
+	builderLayer, err := s.store.Layer(builderImage.TopLayer)
 	if err != nil {
 		return []string{}, fmt.Errorf("%w: failed to get builder layer: %w", ErrStorage, err)
 	}
 
-	interLayer, err := store.Layer(intermediateImage.TopLayer)
+	interLayer, err := s.store.Layer(intermediateImage.TopLayer)
 	if err != nil {
 		return []string{}, fmt.Errorf("%w: failed to get intermediate layer: %w", ErrStorage, err)
 	}
 
-	included, err := saveDiff(store, path, interLayer.ID, builderLayer.ID, sources)
+	included, err := s.saveDiff(path, interLayer.ID, builderLayer.ID, sources)
 	if err != nil {
 		return []string{}, err
 	}
@@ -269,8 +261,7 @@ func getIntermediateContent(
 	return included, nil
 }
 
-func saveDiff(
-	store storage.Store,
+func (s *Scanner) saveDiff(
 	dest string,
 	layerId string,
 	parentId string,
@@ -281,7 +272,7 @@ func saveDiff(
 		Compression: &compression,
 	}
 
-	diff, err := store.Diff(parentId, layerId, &opts)
+	diff, err := s.store.Diff(parentId, layerId, &opts)
 	if err != nil {
 		return []string{}, fmt.Errorf("%w: failed to compute layer diff: %w", ErrStorage, err)
 	}
@@ -340,11 +331,11 @@ func saveDiff(
 // completes, so a valid match is returned even if other images in the
 // store are invalid. Returns all accumulated errors only if no match
 // is found.
-func findIntermediateImage(
-	store storage.Store, client storageclient.Client, stageAlias string,
+func (s *Scanner) findIntermediateImage(
+	stageAlias string,
 ) (*storage.Image, bool, error) {
 
-	images, err := store.Images()
+	images, err := s.store.Images()
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to list images: %w", err)
 	}
@@ -355,7 +346,7 @@ func findIntermediateImage(
 			continue
 		}
 
-		cfg, err := client.GetImageConfig(images[i].ID)
+		cfg, err := s.sclient.GetImageConfig(images[i].ID)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("getting image config for intermediate image %s: %w", images[i].ID, err))
 			continue
@@ -382,7 +373,7 @@ func findIntermediateImage(
 		}
 
 		if stageName == stageAlias {
-			log.Printf("Found intermediate image %s for stage %q.", images[i].ID, stageAlias)
+			s.logger.Debug("found intermediate image", "imageID", images[i].ID, "stage", stageAlias)
 			return &images[i], true, nil
 		}
 	}
@@ -393,10 +384,11 @@ func findIntermediateImage(
 			stageAlias, len(errs), errors.Join(errs...),
 		)
 	}
-	log.Printf("No intermediate image found for stage %q. "+
-		"This is expected if the stage has no filesystem-changing instructions. "+
-		"If the stage does have such instructions, ensure the build was executed "+
-		"with --save-stages --stage-labels flags.", stageAlias)
+	s.logger.Debug("no intermediate image found for stage",
+		"stage", stageAlias,
+		"hint", "expected if the stage has no filesystem-changing instructions; "+
+			"if it does, ensure the build used --save-stages --stage-labels flags",
+	)
 	return nil, false, nil
 }
 

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -102,9 +102,9 @@ func (testCase *TestCase) build(store storage.Store, buildahBinary string) error
 	return nil
 }
 
-func (testCase *TestCase) run(t *testing.T, store storage.Store, buildahBinary string) error {
-	defer testCase.cleanUp(t, store)
-	if err := testCase.build(store, buildahBinary); err != nil {
+func (testCase *TestCase) run(t *testing.T, scanner *Scanner, buildahBinary string) error {
+	defer testCase.cleanUp(t, scanner.store)
+	if err := testCase.build(scanner.store, buildahBinary); err != nil {
 		return err
 	}
 
@@ -113,7 +113,7 @@ func (testCase *TestCase) run(t *testing.T, store storage.Store, buildahBinary s
 		return err
 	}
 
-	result, err := Scan(stages)
+	result, err := scanner.Scan(stages)
 	if err != nil {
 		return err
 	}
@@ -2129,9 +2129,9 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 	}
-	store, err := SetupStore()
+	scanner, err := NewScanner()
 	if err != nil {
-		t.Fatalf("Failed to setup store: %+v", err)
+		t.Fatalf("Failed to create scanner: %+v", err)
 	}
 
 	buildahBinary := getBuildahBinary(t)
@@ -2142,7 +2142,7 @@ func TestIntegration(t *testing.T) {
 				t.Skip(tc.SkipTestReason)
 			}
 			normalizeTestCaseTags(&tc)
-			if err := tc.run(t, store, buildahBinary); err != nil {
+			if err := tc.run(t, scanner, buildahBinary); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -2164,6 +2164,11 @@ func TestIntegrationScanErrors(t *testing.T) {
 		},
 	}
 
+	scanner, err := NewScanner()
+	if err != nil {
+		t.Fatalf("Failed to create scanner: %+v", err)
+	}
+
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			stages, err := containerfile.Parse(strings.NewReader(tc.ContainerfileContent), containerfile.BuildOptions{})
@@ -2171,7 +2176,7 @@ func TestIntegrationScanErrors(t *testing.T) {
 				t.Fatalf("Failed to parse containerfile: %v", err)
 			}
 
-			_, err = Scan(stages)
+			_, err = scanner.Scan(stages)
 			if !errors.Is(err, tc.ExpectedError) {
 				t.Fatalf("expected %v, got: %v", tc.ExpectedError, err)
 			}

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -3,7 +3,7 @@ package capo
 import (
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -67,7 +67,54 @@ var ErrPullspecResolve = errors.New("failed to resolve pullspec")
 var ErrOCIConfig = errors.New("failed to get OCIImageConfig")
 var ErrReferenceParse = errors.New("failed to parse image reference")
 
-func SetupStore() (storage.Store, error) {
+// Scanner exposes methods used for scanning of buildah image builds, assigning
+// image origins to SBOM packages present in a built image.
+type Scanner struct {
+	logger *slog.Logger
+	sclient storageclient.Client
+	store storage.Store
+}
+
+// Enable Scanner to use the functional options pattern for configuration
+type Option func(*Scanner)
+
+// Configure the Scanner to use the passed *slog.Logger for its logging.
+func WithLogger(l *slog.Logger) Option {
+	return func (s *Scanner) {
+		s.logger = l
+	}
+}
+
+// Create a new Scanner with the specified options or fail if an error occurred
+// while trying to set up the containers/storage store.
+func NewScanner(opts ...Option) (*Scanner, error) {
+	// Tech debt: Scanner uses both the storageclient (for
+	// resolving pullspecs and fetching OCIImageConfigs) that uses
+	// storage.Store internally and the raw storage.Store struct. This was
+	// done for ease of testing some features via a mock client. Ideally we
+	// would only have the storageclient implementation, so we had full control
+	// over unit testing.
+	store, err := setupStore()
+	if err != nil {
+		return nil, err
+	}
+
+	sclient := storageclient.NewBuildahClient(store)
+
+	s := &Scanner{
+		logger:  slog.Default(),
+		sclient: sclient,
+		store:   store,
+	}
+
+	for _, o := range opts {
+		o(s)
+	}
+
+	return s, nil
+}
+
+func setupStore() (storage.Store, error) {
 	// The containers/storage library requires this to run for some operations
 	if reexec.Init() {
 		return nil, fmt.Errorf("%w: failed to init reexec", ErrStorageSetup)
@@ -90,38 +137,25 @@ func SetupStore() (storage.Store, error) {
 // extracts relevant content from buildah storage and scans it using syft.
 // Returns a PackageMetadata struct containing packages and their origin information
 // for resolution by Mobster.
-func Scan(
+func (s *Scanner) Scan(
 	stages []containerfile.Stage,
 ) (PackageMetadata, error) {
 	res := PackageMetadata{
 		Packages: make([]PackageMetadataItem, 0),
 	}
-	log.Printf("[STAGES] %+v", stages)
+	s.logger.Debug("parsed containerfile stages", "stages", stages)
 
-	store, err := SetupStore()
+	digests, err := getImageDigests(s.sclient, stages)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
 
-	// Tech debt: in this function, we use both the storageclient (for
-	// resolving pullspecs and fetching OCIImageConfigs) that uses
-	// storage.Store internally and the raw storage.Store struct. This was
-	// done for ease of testing some features via a mock client. Ideally we
-	// would only have the storageclient implementation, so we had full control
-	// over unit testing.
-	storageClient := storageclient.NewBuildahClient(store)
-
-	digests, err := getImageDigests(storageClient, stages)
-	if err != nil {
-		return PackageMetadata{}, err
-	}
-
-	pkgSources, err := getPackageSources(storageClient, stages, digests)
+	pkgSources, err := getPackageSources(s.sclient, stages, digests)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
 	for _, pkgSource := range pkgSources {
-		stagePkgItems, err := scanSource(store, storageClient, pkgSource)
+		stagePkgItems, err := s.scanSource(pkgSource)
 		if err != nil {
 			return PackageMetadata{}, fmt.Errorf("failed to scan source %+v with error: %w", pkgSource, err)
 		}
@@ -390,9 +424,7 @@ func resolveRelativeDestination(cp containerfile.Copy, baseWorkdir string) strin
 // scanSource uses the passed initialized storage.Store struct to syft scan content
 // from the passed packageSource. Returns a slice of PackageMetadataItem structs specifying
 // origins of packages.
-func scanSource(
-	store storage.Store,
-	client storageclient.Client,
+func (s *Scanner) scanSource(
 	pkgSource packageSource,
 ) (_ []PackageMetadataItem, err error) {
 	// builder content is content that is present in a builder stage base image
@@ -411,8 +443,8 @@ func scanSource(
 	// and don't remove the temporary directories
 	debugMode := os.Getenv("CAPO_DEBUG") != ""
 	if debugMode {
-		log.Printf("[DEBUG] Builder %s content path: %s", pkgSource.pullspec, builderContentPath)
-		log.Printf("[DEBUG] Intermediate %s content path: %s", pkgSource.pullspec, intermediateContentPath)
+		s.logger.Debug("builder content path", "pullspec", pkgSource.pullspec, "path", builderContentPath)
+		s.logger.Debug("intermediate content path", "pullspec", pkgSource.pullspec, "path", intermediateContentPath)
 	} else {
 		defer func() {
 			removeErr := errors.Join(
@@ -425,7 +457,7 @@ func scanSource(
 		}()
 	}
 
-	err = getContent(store, client, pkgSource, builderContentPath, intermediateContentPath)
+	err = s.getContent(pkgSource, builderContentPath, intermediateContentPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refactor scanning so that client code using the capo library needs to create a `Scanner` struct, before scanning. This allows us to expose a logging interface that client code can use to customize logging inside the library.