### PR TITLE
fix(ISV-7171): mark RUN --mounts as unsupported

### DIFF
--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -55,36 +55,36 @@ type Copy struct {
 
 // A mount reference from a RUN --mount instruction in a Containerfile stage.
 type Mount struct {
-	// Alias of the stage the mount references when Mount.Type==MountTypeBuilder
-	// or a pullspec when Mount.Type==MountTypeExternal
+	// Alias of the stage the mount references when Mount.Origin==MountOriginBuilder
+	// or a pullspec when Mount.Origin==MountOriginExternal
 	From string
-	// Type of the mount. Specifies whether it references a builder stage
+	// OriginType of the mount. Specifies whether it references a builder stage
 	// or an external image directly.
-	Type MountType
+	OriginType MountOriginType
 	// Type of the mount as specified in the RUN --mount instruction.
-	// There are only two valid types: bind and cache.
-	BuildahMountType BuildahMountType
+	MountType MountType
 }
 
-// MountType classifies a RUN --mount reference by its source origin.
-type MountType int
+// MountOriginType classifies a RUN --mount reference by its source origin.
+type MountOriginType int
 
 const (
-	// MountTypeBuilder indicates a mount from a previous builder stage.
-	MountTypeBuilder MountType = iota
-	// MountTypeExternal indicates a mount directly from an external image.
-	MountTypeExternal
+	// MountOriginBuilder indicates a mount from a previous builder stage.
+	MountOriginBuilder MountOriginType = iota
+	// MountOriginExternal indicates a mount directly from an external image.
+	MountOriginExternal
 )
 
-// BuildahMountType classifies a RUN --mount instruction by its type.
-type BuildahMountType int
+// MountType classifies a RUN --mount instruction by its type.
+type MountType int
 
+// See values https://docs.docker.com/reference/dockerfile/#run---mount
 const (
-	BuildahMountTypeBind BuildahMountType = iota
-	BuildahMountTypeCache
-	BuildahMountTypeTmpfs
-	BuildahMountTypeSecret
-	BuildahMountTypeSSH
+	MountTypeBind MountType = iota
+	MountTypeCache
+	MountTypeTmpfs
+	MountTypeSecret
+	MountTypeSSH
 )
 
 // A builder or final stage in a Containerfile
@@ -310,31 +310,31 @@ func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, er
 		}
 	}
 
-	mountType := MountTypeExternal
+	originType := MountOriginExternal
 	if isStageRef(from, stageNames) {
-		mountType = MountTypeBuilder
+		originType = MountOriginBuilder
 	}
 
-	var buildahMountType BuildahMountType
+	var mountType MountType
 	switch buildahMountTypeStr {
 	case "bind", "": // "bind" is the default in Buildah.
-		buildahMountType = BuildahMountTypeBind
+		mountType = MountTypeBind
 	case "cache":
-		buildahMountType = BuildahMountTypeCache
+		mountType = MountTypeCache
 	case "tmpfs":
-		buildahMountType = BuildahMountTypeTmpfs
+		mountType = MountTypeTmpfs
 	case "secret":
-		buildahMountType = BuildahMountTypeSecret
+		mountType = MountTypeSecret
 	case "ssh":
-		buildahMountType = BuildahMountTypeSSH
+		mountType = MountTypeSSH
 	default:
 		return nil, fmt.Errorf("%w: invalid buildah mount type: %s", ErrParse, buildahMountTypeStr)
 	}
 
 	return &Mount{
-		From:             from,
-		Type:             mountType,
-		BuildahMountType: buildahMountType,
+		From:       from,
+		OriginType: originType,
+		MountType:  mountType,
 	}, nil
 }
 

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -317,7 +317,7 @@ func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, er
 
 	var buildahMountType BuildahMountType
 	switch buildahMountTypeStr {
-	case "bind":
+	case "bind", "": // "bind" is the default in Buildah.
 		buildahMountType = BuildahMountTypeBind
 	case "cache":
 		buildahMountType = BuildahMountTypeCache

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -61,6 +61,9 @@ type Mount struct {
 	// Type of the mount. Specifies whether it references a builder stage
 	// or an external image directly.
 	Type MountType
+	// Type of the mount as specified in the RUN --mount instruction.
+	// There are only two valid types: bind and cache.
+	BuildahMountType BuildahMountType
 }
 
 // MountType classifies a RUN --mount reference by its source origin.
@@ -71,6 +74,17 @@ const (
 	MountTypeBuilder MountType = iota
 	// MountTypeExternal indicates a mount directly from an external image.
 	MountTypeExternal
+)
+
+// BuildahMountType classifies a RUN --mount instruction by its type.
+type BuildahMountType int
+
+const (
+	BuildahMountTypeBind BuildahMountType = iota
+	BuildahMountTypeCache
+	BuildahMountTypeTmpfs
+	BuildahMountTypeSecret
+	BuildahMountTypeSSH
 )
 
 // A builder or final stage in a Containerfile
@@ -276,7 +290,7 @@ func parseMounts(node *parser.Node, env []string, stageNames []string) ([]Mount,
 // parseMount parses a single --mount option string (without the --mount= prefix)
 // and returns a Mount if it is a bind mount with a from reference, or nil otherwise.
 func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, error) {
-	var from, buildahMountType string
+	var from, buildahMountTypeStr string
 	for opt := range strings.SplitSeq(mountOpts, ",") {
 		if from == "" {
 			if val, ok := strings.CutPrefix(opt, "from="); ok {
@@ -288,29 +302,39 @@ func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, er
 				continue
 			}
 		}
-		if buildahMountType == "" {
+		if buildahMountTypeStr == "" {
 			if val, ok := strings.CutPrefix(opt, "type="); ok {
-				buildahMountType = val
+				buildahMountTypeStr = val
 				continue
 			}
 		}
 	}
 
-	// Only bind mounts with a "from" reference are relevant
-	// to contextualization. Without a "from" reference, this
-	// would mount the context directory and not any image.
-	if from == "" || buildahMountType != "bind" {
-		return nil, nil
+	mountType := MountTypeExternal
+	if isStageRef(from, stageNames) {
+		mountType = MountTypeBuilder
 	}
 
-	mountType := MountTypeBuilder
-	if !isStageRef(from, stageNames) {
-		mountType = MountTypeExternal
+	var buildahMountType BuildahMountType
+	switch buildahMountTypeStr {
+	case "bind":
+		buildahMountType = BuildahMountTypeBind
+	case "cache":
+		buildahMountType = BuildahMountTypeCache
+	case "tmpfs":
+		buildahMountType = BuildahMountTypeTmpfs
+	case "secret":
+		buildahMountType = BuildahMountTypeSecret
+	case "ssh":
+		buildahMountType = BuildahMountTypeSSH
+	default:
+		return nil, fmt.Errorf("%w: invalid buildah mount type: %s", ErrParse, buildahMountTypeStr)
 	}
 
 	return &Mount{
-		From: from,
-		Type: mountType,
+		From:             from,
+		Type:             mountType,
+		BuildahMountType: buildahMountType,
 	}, nil
 }
 

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -279,7 +279,6 @@ func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, er
 	var from, buildahMountType string
 	for opt := range strings.SplitSeq(mountOpts, ",") {
 		if from == "" {
-
 			if val, ok := strings.CutPrefix(opt, "from="); ok {
 				var err error
 				from, err = imagebuilder.ProcessWord(val, env)
@@ -297,6 +296,9 @@ func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, er
 		}
 	}
 
+	// Only bind mounts with a "from" reference are relevant
+	// to contextualization. Without a "from" reference, this
+	// would mount the context directory and not any image.
 	if from == "" || buildahMountType != "bind" {
 		return nil, nil
 	}

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -262,35 +262,54 @@ func parseMounts(node *parser.Node, env []string, stageNames []string) ([]Mount,
 		if !strings.HasPrefix(fl, "--mount=") {
 			continue
 		}
+		mount, err := parseMount(strings.TrimPrefix(fl, "--mount="), env, stageNames)
+		if err != nil {
+			return nil, err
+		}
+		if mount != nil {
+			mounts = append(mounts, *mount)
+		}
+	}
+	return mounts, nil
+}
 
-		mountOpts := strings.TrimPrefix(fl, "--mount=")
-		from := ""
-		for opt := range strings.SplitSeq(mountOpts, ",") {
+// parseMount parses a single --mount option string (without the --mount= prefix)
+// and returns a Mount if it is a bind mount with a from reference, or nil otherwise.
+func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, error) {
+	var from, buildahMountType string
+	for opt := range strings.SplitSeq(mountOpts, ",") {
+		if from == "" {
+
 			if val, ok := strings.CutPrefix(opt, "from="); ok {
 				var err error
 				from, err = imagebuilder.ProcessWord(val, env)
 				if err != nil {
 					return nil, fmt.Errorf("%w: %w", ErrParse, err)
 				}
-				break
+				continue
 			}
 		}
-
-		if from == "" {
-			continue
+		if buildahMountType == "" {
+			if val, ok := strings.CutPrefix(opt, "type="); ok {
+				buildahMountType = val
+				continue
+			}
 		}
-
-		mountType := MountTypeBuilder
-		if !isStageRef(from, stageNames) {
-			mountType = MountTypeExternal
-		}
-
-		mounts = append(mounts, Mount{
-			From: from,
-			Type: mountType,
-		})
 	}
-	return mounts, nil
+
+	if from == "" || buildahMountType != "bind" {
+		return nil, nil
+	}
+
+	mountType := MountTypeBuilder
+	if !isStageRef(from, stageNames) {
+		mountType = MountTypeExternal
+	}
+
+	return &Mount{
+		From: from,
+		Type: mountType,
+	}, nil
 }
 
 // normalizeSources normalizes the paths in the passed sources slice to absolute clean paths.

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -55,25 +55,15 @@ type Copy struct {
 
 // A mount reference from a RUN --mount instruction in a Containerfile stage.
 type Mount struct {
-	// Alias of the stage the mount references when Mount.Origin==MountOriginBuilder
-	// or a pullspec when Mount.Origin==MountOriginExternal
-	From string
-	// OriginType of the mount. Specifies whether it references a builder stage
-	// or an external image directly.
-	OriginType MountOriginType
+	// Value of the --from field in the RUN command for bind and cache mount types.
+	FromRaw string
+	// Pullspec of an image used in the --from field, if the value is a reference
+	// to an image, empty otherwise. Note that the pullspec may be incomplete,
+	// it is directly copied from the FROM instruction in the stage where relevant.
+	Pullspec string
 	// Type of the mount as specified in the RUN --mount instruction.
 	MountType MountType
 }
-
-// MountOriginType classifies a RUN --mount reference by its source origin.
-type MountOriginType int
-
-const (
-	// MountOriginBuilder indicates a mount from a previous builder stage.
-	MountOriginBuilder MountOriginType = iota
-	// MountOriginExternal indicates a mount directly from an external image.
-	MountOriginExternal
-)
 
 // MountType classifies a RUN --mount instruction by its type.
 type MountType int
@@ -290,7 +280,7 @@ func parseMounts(node *parser.Node, env []string, stageNames []string) ([]Mount,
 // parseMount parses a single --mount option string (without the --mount= prefix)
 // and returns a Mount if it is a bind mount with a from reference, or nil otherwise.
 func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, error) {
-	var from, buildahMountTypeStr string
+	var from, buildahMountTypeStr, pullspec string
 	for opt := range strings.SplitSeq(mountOpts, ",") {
 		if from == "" {
 			if val, ok := strings.CutPrefix(opt, "from="); ok {
@@ -310,9 +300,9 @@ func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, er
 		}
 	}
 
-	originType := MountOriginExternal
-	if isStageRef(from, stageNames) {
-		originType = MountOriginBuilder
+	if !isStageRef(from, stageNames) {
+		// populate pullspec only if it is not a stage reference
+		pullspec = from
 	}
 
 	var mountType MountType
@@ -332,9 +322,9 @@ func parseMount(mountOpts string, env []string, stageNames []string) (*Mount, er
 	}
 
 	return &Mount{
-		From:       from,
-		OriginType: originType,
-		MountType:  mountType,
+		FromRaw:   from,
+		Pullspec:  pullspec,
+		MountType: mountType,
 	}, nil
 }
 

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -651,6 +651,27 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		"run with mount is parsed correctly": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							FROM scratch
+							RUN --mount=type=bind,from=builder,src=/app,dst=/app ls /app
+							RUN --mount=type=cache,from=quay.io/builder,src=/cache,dst=/cache ls /cache`,
+			expected: []Stage{
+				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}, Mounts: []Mount{}},
+				{Alias: FinalStage, Base: "scratch", Copies: []Copy{}, Mounts: []Mount{
+					{
+						From:             "builder",
+						Type:             MountTypeBuilder,
+						BuildahMountType: BuildahMountTypeBind,
+					},
+					{
+						From:             "quay.io/builder",
+						Type:             MountTypeExternal,
+						BuildahMountType: BuildahMountTypeCache,
+					},
+				}},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -132,9 +132,8 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{
 						{
-							From:       "builder1",
-							OriginType: MountOriginBuilder,
-							MountType:  MountTypeBind,
+							FromRaw:   "builder1",
+							MountType: MountTypeBind,
 						},
 					},
 				},
@@ -538,7 +537,7 @@ func TestParse(t *testing.T) {
 					Base:   "quay.io/rhel:9",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "quay.io/tools:1", OriginType: MountOriginExternal},
+						{FromRaw: "quay.io/tools:1", Pullspec: "quay.io/tools:1"},
 					},
 				},
 			},
@@ -559,7 +558,7 @@ func TestParse(t *testing.T) {
 					Base:   "scratch",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "builder", OriginType: MountOriginBuilder},
+						{FromRaw: "builder"},
 					},
 				},
 			},
@@ -580,7 +579,7 @@ func TestParse(t *testing.T) {
 					Base:   "scratch",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "0", OriginType: MountOriginBuilder},
+						{FromRaw: "0"},
 					},
 				},
 			},
@@ -702,14 +701,13 @@ func TestParse(t *testing.T) {
 				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}, Mounts: []Mount{}},
 				{Alias: FinalStage, Base: "scratch", Copies: []Copy{}, Mounts: []Mount{
 					{
-						From:       "builder",
-						OriginType: MountOriginBuilder,
-						MountType:  MountTypeBind,
+						FromRaw:   "builder",
+						MountType: MountTypeBind,
 					},
 					{
-						From:       "quay.io/builder",
-						OriginType: MountOriginExternal,
-						MountType:  MountTypeCache,
+						FromRaw:   "quay.io/builder",
+						Pullspec:  "quay.io/builder",
+						MountType: MountTypeCache,
 					},
 				}},
 			},

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -92,11 +92,53 @@ func TestParse(t *testing.T) {
 							From:        "builder",
 							Sources:     []string{"/usr/bin/binary"},
 							Destination: "/usr/bin/binary",
-							Type:        CopyTypeBuilder,
 						},
 					},
 					Mounts: []Mount{},
 				},
+			}},
+		"alias arg evaluation": {
+			containerfile: `ARG zero=0
+							ARG one=1
+							FROM docker.io/library/fedora as builder0
+							FROM docker.io/library/alpine:latest as builder1
+							FROM builder${one} as somethingelse
+							COPY --from=builder${zero} /usr/bin/oras /usr/bin/oras
+							RUN --mount=from=builder${one},type=bind,src=/usr/bin/binary,dst=/usr/bin/binary ls /usr/bin/binary
+							FROM scratch`,
+			expected: []Stage{
+				{
+					Alias:  "builder0",
+					Base:   "docker.io/library/fedora",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+				},
+				{
+					Alias:  "builder1",
+					Base:   "docker.io/library/alpine:latest",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+				},
+				{
+					Alias: "somethingelse",
+					Base:  "builder1",
+					Copies: []Copy{
+						{
+							From:        "builder0",
+							Sources:     []string{"/usr/bin/oras"},
+							Destination: "/usr/bin/oras",
+							Type:        CopyTypeBuilder,
+						},
+					},
+					Mounts: []Mount{
+						{
+							From:       "builder1",
+							OriginType: MountOriginBuilder,
+							MountType:  MountTypeBind,
+						},
+					},
+				},
+				{Base: "scratch", Alias: FinalStage, Copies: []Copy{}, Mounts: []Mount{}},
 			},
 		},
 		"build target": {
@@ -496,7 +538,7 @@ func TestParse(t *testing.T) {
 					Base:   "quay.io/rhel:9",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "quay.io/tools:1", Type: MountTypeExternal},
+						{From: "quay.io/tools:1", OriginType: MountOriginExternal},
 					},
 				},
 			},
@@ -517,7 +559,7 @@ func TestParse(t *testing.T) {
 					Base:   "scratch",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "builder", Type: MountTypeBuilder},
+						{From: "builder", OriginType: MountOriginBuilder},
 					},
 				},
 			},
@@ -538,7 +580,7 @@ func TestParse(t *testing.T) {
 					Base:   "scratch",
 					Copies: []Copy{},
 					Mounts: []Mount{
-						{From: "0", Type: MountTypeBuilder},
+						{From: "0", OriginType: MountOriginBuilder},
 					},
 				},
 			},
@@ -660,14 +702,14 @@ func TestParse(t *testing.T) {
 				{Alias: "builder", Base: "quay.io/rhel:9", Copies: []Copy{}, Mounts: []Mount{}},
 				{Alias: FinalStage, Base: "scratch", Copies: []Copy{}, Mounts: []Mount{
 					{
-						From:             "builder",
-						Type:             MountTypeBuilder,
-						BuildahMountType: BuildahMountTypeBind,
+						From:       "builder",
+						OriginType: MountOriginBuilder,
+						MountType:  MountTypeBind,
 					},
 					{
-						From:             "quay.io/builder",
-						Type:             MountTypeExternal,
-						BuildahMountType: BuildahMountTypeCache,
+						From:       "quay.io/builder",
+						OriginType: MountOriginExternal,
+						MountType:  MountTypeCache,
 					},
 				}},
 			},

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1830,192 +1830,6 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 		},
-		"[RUN --mount] --mount from external image in builder stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
-			TestImage: BuildDefinition{
-				Tag: "test-mount-external-in-builder",
-				ContainerfileContent: `FROM localhost/mount-ext-base:latest AS builder
-										COPY go_exp.mod /opt/app3/go.mod
-										RUN --mount=type=bind,from=localhost/mount-ext-source:latest,target=/mnt mkdir -p /opt/app2 && cp /mnt/go.mod /opt/app2/go.mod
-
-										FROM scratch
-										COPY --from=builder /opt /opt`,
-				ContextDirectory: "../testdata/image_content",
-			},
-			BuilderImages: []BuildDefinition{
-				{
-					Tag: "localhost/mount-ext-base:latest",
-					ContainerfileContent: `FROM docker.io/library/alpine:latest
-											COPY go_syft.mod /opt/app1/go.mod`,
-					ContextDirectory: "../testdata/image_content",
-				},
-				{
-					Tag: "localhost/mount-ext-source:latest",
-					ContainerfileContent: `FROM scratch
-											COPY go_uuid.mod /go.mod`,
-					ContextDirectory: "../testdata/image_content",
-				},
-			},
-			ExpectedResult: PackageMetadata{
-				Packages: []PackageMetadataItem{
-					{
-						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
-						OriginType: "builder",
-						Pullspec:   "localhost/mount-ext-base@sha256:dummy",
-						StageAlias: "builder",
-					},
-					{
-						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
-						OriginType: "external",
-						Pullspec:   "localhost/mount-ext-source@sha256:dummy",
-						StageAlias: "builder",
-					},
-					{
-						PackageURL: "pkg:golang/golang.org/x/exp@v0.0.0-20240808152545-0cdaa3abc0fa",
-						OriginType: "intermediate",
-						Pullspec:   "localhost/mount-ext-base@sha256:dummy",
-						StageAlias: "builder",
-					},
-				},
-			},
-		},
-		"[RUN --mount] --mount from builder stage in another builder stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
-			TestImage: BuildDefinition{
-				Tag: "test-mount-builder-stage",
-				ContainerfileContent: `FROM localhost/mount-stage-base:latest AS provider
-										COPY go_uuid.mod /provided/go.mod
-
-										FROM localhost/mount-stage-base2:latest AS consumer
-										COPY go_exp.mod /opt/app3/go.mod
-										RUN --mount=type=bind,from=provider,target=/mnt mkdir -p /opt/app2 && cp /mnt/provided/go.mod /opt/app2/go.mod
-
-										FROM scratch
-										COPY --from=consumer /opt /opt`,
-				ContextDirectory: "../testdata/image_content",
-			},
-			BuilderImages: []BuildDefinition{
-				{
-					Tag: "localhost/mount-stage-base:latest",
-					ContainerfileContent: `FROM scratch
-											COPY go_syft.mod /opt/app0/go.mod`,
-					ContextDirectory: "../testdata/image_content",
-				},
-				{
-					Tag: "localhost/mount-stage-base2:latest",
-					ContainerfileContent: `FROM docker.io/library/alpine:latest
-											COPY go_sync.mod /opt/app1/go.mod`,
-					ContextDirectory: "../testdata/image_content",
-				},
-			},
-			ExpectedResult: PackageMetadata{
-				Packages: []PackageMetadataItem{
-					{
-						PackageURL: "pkg:golang/golang.org/x/sync@v0.8.0",
-						OriginType: "builder",
-						Pullspec:   "localhost/mount-stage-base2@sha256:dummy",
-						StageAlias: "consumer",
-					},
-					{
-						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
-						OriginType: "intermediate",
-						Pullspec:   "localhost/mount-stage-base@sha256:dummy",
-						StageAlias: "provider",
-					},
-					{
-						PackageURL: "pkg:golang/golang.org/x/exp@v0.0.0-20240808152545-0cdaa3abc0fa",
-						OriginType: "intermediate",
-						Pullspec:   "localhost/mount-stage-base2@sha256:dummy",
-						StageAlias: "consumer",
-					},
-				},
-			},
-		},
-		"[RUN --mount] --mount from external image in final stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
-			TestImage: BuildDefinition{
-				Tag: "test-mount-external-final",
-				ContainerfileContent: `FROM localhost/mount-ext-final-base:latest AS builder
-										COPY go_exp.mod /opt/app3/go.mod
-
-										FROM docker.io/library/alpine:latest
-										RUN --mount=type=bind,from=localhost/mount-ext-final-source:latest,target=/mnt mkdir -p /opt/app2 && cp /mnt/go.mod /opt/app2/go.mod
-										COPY --from=builder /opt /opt`,
-				ContextDirectory: "../testdata/image_content",
-			},
-			BuilderImages: []BuildDefinition{
-				{
-					Tag: "localhost/mount-ext-final-base:latest",
-					ContainerfileContent: `FROM scratch
-											COPY go_syft.mod /opt/app1/go.mod`,
-					ContextDirectory: "../testdata/image_content",
-				},
-				{
-					Tag: "localhost/mount-ext-final-source:latest",
-					ContainerfileContent: `FROM scratch
-											COPY go_uuid.mod /go.mod`,
-					ContextDirectory: "../testdata/image_content",
-				},
-			},
-			ExpectedResult: PackageMetadata{
-				Packages: []PackageMetadataItem{
-					{
-						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
-						OriginType: "builder",
-						Pullspec:   "localhost/mount-ext-final-base@sha256:dummy",
-						StageAlias: "builder",
-					},
-					{
-						PackageURL: "pkg:golang/golang.org/x/exp@v0.0.0-20240808152545-0cdaa3abc0fa",
-						OriginType: "intermediate",
-						Pullspec:   "localhost/mount-ext-final-base@sha256:dummy",
-						StageAlias: "builder",
-					},
-					{
-						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
-						OriginType: "external",
-						Pullspec:   "localhost/mount-ext-final-source@sha256:dummy",
-					},
-				},
-			},
-		},
-		"[RUN --mount] --mount from builder stage in final stage": {
-			SkipTestReason: "[Priority: high] capo does not trace content through RUN --mount",
-			TestImage: BuildDefinition{
-				Tag: "test-mount-builder-final",
-				ContainerfileContent: `FROM localhost/mount-builder-final-base:latest AS builder
-										COPY go_exp.mod /opt/app2/go.mod
-
-										FROM docker.io/library/alpine:latest
-										RUN --mount=type=bind,from=builder,target=/mnt mkdir -p /opt/app1 && cp /mnt/opt/app1/go.mod /opt/app1/go.mod
-										RUN --mount=type=bind,from=builder,target=/mnt mkdir -p /opt/app2 && cp /mnt/opt/app2/go.mod /opt/app2/go.mod`,
-				ContextDirectory: "../testdata/image_content",
-			},
-			BuilderImages: []BuildDefinition{
-				{
-					Tag: "localhost/mount-builder-final-base:latest",
-					ContainerfileContent: `FROM scratch
-											COPY go_syft.mod /opt/app1/go.mod`,
-					ContextDirectory: "../testdata/image_content",
-				},
-			},
-			ExpectedResult: PackageMetadata{
-				Packages: []PackageMetadataItem{
-					{
-						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
-						OriginType: "builder",
-						Pullspec:   "localhost/mount-builder-final-base@sha256:dummy",
-						StageAlias: "builder",
-					},
-					{
-						PackageURL: "pkg:golang/golang.org/x/exp@v0.0.0-20240808152545-0cdaa3abc0fa",
-						OriginType: "intermediate",
-						Pullspec:   "localhost/mount-builder-final-base@sha256:dummy",
-						StageAlias: "builder",
-					},
-				},
-			},
-		},
 		"[WORKDIR] WORKDIR set in intermediate image": {
 			TestImage: BuildDefinition{
 				Tag: "test-workdir-relative-dest",
@@ -2161,6 +1975,15 @@ func TestIntegrationScanErrors(t *testing.T) {
 								   FROM scratch
 								   COPY --from=builder /file /file`,
 			ExpectedError: ErrPullspecResolve,
+		},
+		"[RUN --mount] --mount from external image in builder stage": {
+			ContainerfileContent: `FROM localhost/mount-ext-base:latest AS builder
+									COPY go_exp.mod /opt/app3/go.mod
+									RUN --mount=type=bind,from=localhost/mount-ext-source:latest,target=/mnt mkdir -p /opt/app2 && cp /mnt/go.mod /opt/app2/go.mod
+
+									FROM scratch
+									COPY --from=builder /opt /opt`,
+			ExpectedError: ErrUnsupportedFeature,
 		},
 	}
 

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1983,7 +1983,7 @@ func TestIntegrationScanErrors(t *testing.T) {
 
 									FROM scratch
 									COPY --from=builder /opt /opt`,
-			ExpectedError: ErrUnsupportedFeature,
+			ExpectedError: ErrUnsupportedMount,
 		},
 		"[RUN --mount] --mount from external image in final stage": {
 			ContainerfileContent: `FROM localhost/mount-ext-base:latest AS builder
@@ -1992,7 +1992,7 @@ func TestIntegrationScanErrors(t *testing.T) {
 									FROM scratch
 									COPY --from=builder /opt /opt
 									RUN --mount=type=bind,from=localhost/mount-ext-source:latest,target=/mnt mkdir -p /opt/app2 && cp /mnt/go.mod /opt/app2/go.mod`,
-			ExpectedError: ErrUnsupportedFeature,
+			ExpectedError: ErrUnsupportedMount,
 		},
 	}
 

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1985,6 +1985,15 @@ func TestIntegrationScanErrors(t *testing.T) {
 									COPY --from=builder /opt /opt`,
 			ExpectedError: ErrUnsupportedFeature,
 		},
+		"[RUN --mount] --mount from external image in final stage": {
+			ContainerfileContent: `FROM localhost/mount-ext-base:latest AS builder
+									COPY go_exp.mod /opt/app3/go.mod
+
+									FROM scratch
+									COPY --from=builder /opt /opt
+									RUN --mount=type=bind,from=localhost/mount-ext-source:latest,target=/mnt mkdir -p /opt/app2 && cp /mnt/go.mod /opt/app2/go.mod`,
+			ExpectedError: ErrUnsupportedFeature,
+		},
 	}
 
 	scanner, err := NewScanner()

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -167,8 +167,8 @@ func stageRefs(stage containerfile.Stage) []string {
 		}
 	}
 	for _, mount := range stage.Mounts {
-		if mount.OriginType == containerfile.MountOriginBuilder {
-			refs = append(refs, mount.From)
+		if mount.Pullspec == "" {
+			refs = append(refs, mount.FromRaw)
 		}
 	}
 	return refs
@@ -244,10 +244,10 @@ func resolveExtraImages(client storageclient.Client, stages []containerfile.Stag
 		}
 
 		for _, mount := range stage.Mounts {
-			if mount.OriginType != containerfile.MountOriginExternal {
+			if mount.Pullspec == "" {
 				continue
 			}
-			if err := addImage(mount.From); err != nil {
+			if err := addImage(mount.Pullspec); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -167,7 +167,7 @@ func stageRefs(stage containerfile.Stage) []string {
 		}
 	}
 	for _, mount := range stage.Mounts {
-		if mount.Type == containerfile.MountTypeBuilder {
+		if mount.OriginType == containerfile.MountOriginBuilder {
 			refs = append(refs, mount.From)
 		}
 	}
@@ -244,7 +244,7 @@ func resolveExtraImages(client storageclient.Client, stages []containerfile.Stag
 		}
 
 		for _, mount := range stage.Mounts {
-			if mount.Type != containerfile.MountTypeExternal {
+			if mount.OriginType != containerfile.MountOriginExternal {
 				continue
 			}
 			if err := addImage(mount.From); err != nil {

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -137,7 +137,7 @@ func setupStore() (storage.Store, error) {
 func checkUnsupportedFeatures(stages []containerfile.Stage) error {
 	for _, stage := range stages {
 		for _, mount := range stage.Mounts {
-			if mount.BuildahMountType == containerfile.BuildahMountTypeBind && mount.From != "" {
+			if mount.MountType == containerfile.MountTypeBind && mount.From != "" {
 				return fmt.Errorf(
 					"builder content resolution is unsupported for RUN --mount=type=bind: %w",
 					ErrUnsupportedMount,

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -66,7 +66,7 @@ var ErrStorageSetup = errors.New("[ERR_STORAGE_SETUP] failed to set up container
 var ErrPullspecResolve = errors.New("[ERR_PULLSPEC_RESOLVE] failed to resolve pullspec")
 var ErrOCIConfig = errors.New("[ERR_OCI_CONFIG] failed to get OCI image config")
 var ErrSBOMScan = errors.New("[ERR_SBOM_SCAN] SBOM scan failed")
-var ErrUnsupportedFeature = errors.New("[ERR_UNSUPPORTED] unsupported feature")
+var ErrUnsupportedMount = errors.New("[ERR_UNSUPPORTED_MOUNT] unsupported mount type")
 
 // Scanner exposes methods used for scanning of buildah image builds, assigning
 // image origins to SBOM packages present in a built image.
@@ -136,8 +136,13 @@ func setupStore() (storage.Store, error) {
 
 func checkUnsupportedFeatures(stages []containerfile.Stage) error {
 	for _, stage := range stages {
-		if len(stage.Mounts) > 0 {
-			return fmt.Errorf("%w: RUN --mount=type=bind is not supported", ErrUnsupportedFeature)
+		for _, mount := range stage.Mounts {
+			if mount.BuildahMountType == containerfile.BuildahMountTypeBind && mount.From != "" {
+				return fmt.Errorf(
+					"builder content resolution is unsupported for RUN --mount=type=bind: %w",
+					ErrUnsupportedMount,
+				)
+			}
 		}
 	}
 	return nil

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -71,9 +71,9 @@ var ErrUnsupportedFeature = errors.New("[ERR_UNSUPPORTED] unsupported feature")
 // Scanner exposes methods used for scanning of buildah image builds, assigning
 // image origins to SBOM packages present in a built image.
 type Scanner struct {
-	logger *slog.Logger
+	logger  *slog.Logger
 	sclient storageclient.Client
-	store storage.Store
+	store   storage.Store
 }
 
 // Enable Scanner to use the functional options pattern for configuration
@@ -81,7 +81,7 @@ type Option func(*Scanner)
 
 // Configure the Scanner to use the passed *slog.Logger for its logging.
 func WithLogger(l *slog.Logger) Option {
-	return func (s *Scanner) {
+	return func(s *Scanner) {
 		s.logger = l
 	}
 }
@@ -158,7 +158,6 @@ func (s *Scanner) Scan(
 		Packages: make([]PackageMetadataItem, 0),
 	}
 	s.logger.Debug("parsed containerfile stages", "stages", stages)
-
 
 	digests, err := getImageDigests(s.sclient, stages)
 	if err != nil {

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -137,7 +137,7 @@ func setupStore() (storage.Store, error) {
 func checkUnsupportedFeatures(stages []containerfile.Stage) error {
 	for _, stage := range stages {
 		for _, mount := range stage.Mounts {
-			if mount.MountType == containerfile.MountTypeBind && mount.From != "" {
+			if mount.MountType == containerfile.MountTypeBind && mount.FromRaw != "" {
 				return fmt.Errorf(
 					"builder content resolution is unsupported for RUN --mount=type=bind: %w",
 					ErrUnsupportedMount,

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -66,6 +66,7 @@ var ErrStorageSetup = errors.New("[ERR_STORAGE_SETUP] failed to set up container
 var ErrPullspecResolve = errors.New("[ERR_PULLSPEC_RESOLVE] failed to resolve pullspec")
 var ErrOCIConfig = errors.New("[ERR_OCI_CONFIG] failed to get OCI image config")
 var ErrSBOMScan = errors.New("[ERR_SBOM_SCAN] SBOM scan failed")
+var ErrUnsupportedFeature = errors.New("[ERR_UNSUPPORTED] unsupported feature")
 
 // Scanner exposes methods used for scanning of buildah image builds, assigning
 // image origins to SBOM packages present in a built image.
@@ -133,6 +134,15 @@ func setupStore() (storage.Store, error) {
 	return store, nil
 }
 
+func checkUnsupportedFeatures(stages []containerfile.Stage) error {
+	for _, stage := range stages {
+		if len(stage.Mounts) > 0 {
+			return fmt.Errorf("%w: RUN --mount=type=bind is not supported", ErrUnsupportedFeature)
+		}
+	}
+	return nil
+}
+
 // Scan reads the passed containerfile stages, resolves true content origin,
 // extracts relevant content from buildah storage and scans it using syft.
 // Returns a PackageMetadata struct containing packages and their origin information
@@ -140,10 +150,15 @@ func setupStore() (storage.Store, error) {
 func (s *Scanner) Scan(
 	stages []containerfile.Stage,
 ) (PackageMetadata, error) {
+	if err := checkUnsupportedFeatures(stages); err != nil {
+		return PackageMetadata{}, err
+	}
+
 	res := PackageMetadata{
 		Packages: make([]PackageMetadataItem, 0),
 	}
 	s.logger.Debug("parsed containerfile stages", "stages", stages)
+
 
 	digests, err := getImageDigests(s.sclient, stages)
 	if err != nil {


### PR DESCRIPTION
Note: Although this comment contains markdown, it has not been generated by AI and may contain useful insight. :smile: 

# Solution summary

I tried several iterations of making exact content search work, however it proved to be impossible to implement a reliable solution at this time.

## Why?

* We only have intermediate and base images. If images consist of more Containerfile instructions, we cannot attribute which instruction added what content.
* This would be solvable by using `--layers`, however that solution is out of reach for practical reasons.
* I played around with "best effort content search". The best solution I was able to make work:
  * Run through parsed stages, check for `RUN --mount`s and the mounted directory
  * Scan mounted directories
  * Scan everything as usual (we get builder and intermediate content)
  * Iterate through intermediate content from stages which contained `RUN --mount` instruction
  * If these stages contain some content that is also reported to be present in the mounted directory, we just re-attribute it to the mounted image
  * **Problems**:
    * With this approach is that Capo does not report the final stage, so this method is unusable for it. We can either report everything scanned from the mounted directory (could be an entire image) or make Capo scan everything
    * If an intermediate layer adds a tool that is also contained within the mounted directory, it will be incorrectly reported to originate from the mounted image

## What now?

I contacted Erik through Slack and we agreed to mark `RUN --mount` as unsupported. This then needs to be handled in Mobster to fail contextualization and only report the basic SBOM.

I am very much willing to take another look if anyone comes up with fresh ideas.
