### PR TITLE
feat(ISV-7337): parse labels in containerfiles

### DIFF
--- a/cmd/buildprobe/main.go
+++ b/cmd/buildprobe/main.go
@@ -63,13 +63,11 @@ func parseArgs() (args, error) {
 	cliArgs := make(map[string]string)
 	flag.Func(
 		"build-arg",
-		"Build argument passed to buildah in the form KEY=VALUE. Can be used multiple times.",
+		"Build argument in the form KEY=VALUE or bare KEY (inherits from environment). Can be used multiple times.",
 		func(s string) error {
-			key, value, err := buildargs.ParseBuildArgLine(s)
-			if err != nil {
+			if err := buildargs.ReadBuildArg(s, cliArgs); err != nil {
 				return ErrBuildArg
 			}
-			cliArgs[key] = value
 			return nil
 		},
 	)

--- a/cmd/capo/main.go
+++ b/cmd/capo/main.go
@@ -40,13 +40,11 @@ func parseArgs() (args, error) {
 	buildArgs := make(map[string]string)
 	flag.Func(
 		"build-arg",
-		"Build argument passed to buildah in the form KEY=VALUE. Can be used multiple times.",
+		"Build argument in the form KEY=VALUE or bare KEY (inherits from environment). Can be used multiple times.",
 		func(s string) error {
-			key, value, err := buildargs.ParseBuildArgLine(s)
-			if err != nil {
+			if err := buildargs.ReadBuildArg(s, buildArgs); err != nil {
 				return ErrBuildArg
 			}
-			buildArgs[key] = value
 			return nil
 		},
 	)

--- a/cmd/capo/main.go
+++ b/cmd/capo/main.go
@@ -127,11 +127,11 @@ func main() {
 		}
 	}()
 
-	stages, err := containerfile.Parse(r, buildOptsFromArgs(args))
+	cf, err := containerfile.Parse(r, buildOptsFromArgs(args))
 	if err != nil {
 		log.Fatalf("Failed to parse containerfile %+v", err)
 	}
-	log.Printf("Parsed stages: %+v", stages)
+	log.Printf("Parsed stages: %+v", cf.Stages)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
@@ -142,7 +142,7 @@ func main() {
 		log.Fatalf("Failed to create scanner: %+v", err)
 	}
 
-	pkgMetadata, err := scanner.Scan(stages)
+	pkgMetadata, err := scanner.Scan(cf)
 	if err != nil {
 		log.Fatalf("Failed to scan stages: %+v", err)
 	}

--- a/pkg/buildargs/buildargs.go
+++ b/pkg/buildargs/buildargs.go
@@ -12,14 +12,38 @@ import (
 // ErrInvalidBuildArg is returned when a build argument line is not in KEY=VALUE format.
 var ErrInvalidBuildArg = errors.New("invalid build arg")
 
-// ParseBuildArgLine parses a single KEY=VALUE line into its key and value.
-// Values may contain '=' characters.
-func ParseBuildArgLine(s string) (string, string, error) {
-	key, value, ok := strings.Cut(s, "=")
-	if !ok || key == "" {
-		return "", "", fmt.Errorf("%w: expected KEY=VALUE, got %q", ErrInvalidBuildArg, s)
+
+// ReadBuildArg parses a build argument and writes it into args, matching
+// buildah semantics: KEY=VALUE stores the literal value (even if empty),
+// bare KEY inherits from the host environment (or deletes the key if unset).
+func ReadBuildArg(arg string, args map[string]string) error {
+	key, value, hasValue, err := parseBuildArgLine(arg)
+	if err != nil {
+		return err
 	}
-	return key, value, nil
+	if hasValue {
+		args[key] = value
+	} else if val, ok := os.LookupEnv(key); ok {
+		args[key] = val
+	} else {
+		delete(args, key)
+	}
+	return nil
+}
+
+// parseBuildArgLine parses a single build argument string.
+// It accepts both KEY=VALUE (explicit value) and KEY (no equals, inherit from
+// environment). The hasValue return indicates whether an explicit value was
+// provided: true for KEY= or KEY=VALUE, false for bare KEY.
+func parseBuildArgLine(s string) (key string, value string, hasValue bool, err error) {
+	k, v, ok := strings.Cut(s, "=")
+	if k == "" {
+		return "", "", false, fmt.Errorf("%w: empty key in %q", ErrInvalidBuildArg, s)
+	}
+	if !ok {
+		return k, "", false, nil
+	}
+	return k, v, true, nil
 }
 
 // ParseBuildArgFile reads a file of build arguments, one KEY=VALUE per line.
@@ -43,11 +67,9 @@ func ParseBuildArgFile(path string) (result map[string]string, err error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		key, value, err := ParseBuildArgLine(line)
-		if err != nil {
+		if err := ReadBuildArg(line, args); err != nil {
 			return nil, fmt.Errorf("in %s: %w", path, err)
 		}
-		args[key] = value
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("reading %s: %w", path, err)

--- a/pkg/buildargs/buildargs_test.go
+++ b/pkg/buildargs/buildargs_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 package buildargs
 
 import (

--- a/pkg/buildargs/buildargs_test.go
+++ b/pkg/buildargs/buildargs_test.go
@@ -8,42 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestParseBuildArgLine(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name    string
-		input   string
-		wantKey string
-		wantVal string
-		wantErr bool
-	}{
-		{name: "simple", input: "FOO=bar", wantKey: "FOO", wantVal: "bar"},
-		{name: "value with equals", input: "FOO=bar=baz", wantKey: "FOO", wantVal: "bar=baz"},
-		{name: "empty value", input: "FOO=", wantKey: "FOO", wantVal: ""},
-		{name: "no equals", input: "FOOBAR", wantErr: true},
-		{name: "empty key", input: "=value", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			key, val, err := ParseBuildArgLine(tt.input)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got key=%q val=%q", key, val)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if key != tt.wantKey || val != tt.wantVal {
-				t.Errorf("got key=%q val=%q, want key=%q val=%q", key, val, tt.wantKey, tt.wantVal)
-			}
-		})
-	}
-}
-
 func TestParseBuildArgFile(t *testing.T) {
 	t.Parallel()
 	content := `# This is a comment
@@ -90,13 +54,83 @@ func TestParseBuildArgFileInvalidLine(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bad.conf")
-	if err := os.WriteFile(path, []byte("NOEQUALS\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("=value\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	_, err := ParseBuildArgFile(path)
 	if err == nil {
-		t.Fatal("expected error for invalid line")
+		t.Fatal("expected error for empty key")
+	}
+}
+
+func TestParseBuildArgFileBareKeyInheritsFromEnv(t *testing.T) {
+	t.Setenv("INHERIT_ME", "from-env")
+
+	content := "EXPLICIT=value\nINHERIT_ME\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "args.conf")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	args, err := ParseBuildArgFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"EXPLICIT":   "value",
+		"INHERIT_ME": "from-env",
+	}
+	if diff := cmp.Diff(expected, args); diff != "" {
+		t.Errorf("ParseBuildArgFile() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseBuildArgFileBareKeyDeletedWhenNotInEnv(t *testing.T) {
+	t.Parallel()
+
+	content := "KEEP=value\nNOT_IN_ENV\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "args.conf")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	args, err := ParseBuildArgFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"KEEP": "value",
+	}
+	if diff := cmp.Diff(expected, args); diff != "" {
+		t.Errorf("ParseBuildArgFile() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseBuildArgFileExplicitEmptyStaysEmpty(t *testing.T) {
+	t.Setenv("EMPTY_KEY", "should-not-be-used")
+
+	content := "EMPTY_KEY=\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "args.conf")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	args, err := ParseBuildArgFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]string{
+		"EMPTY_KEY": "",
+	}
+	if diff := cmp.Diff(expected, args); diff != "" {
+		t.Errorf("ParseBuildArgFile() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -78,6 +79,7 @@ const (
 )
 
 // A builder or final stage in a Containerfile
+// TODO: encase this in a containerfile struct?
 type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final.
 	Alias string
@@ -93,6 +95,8 @@ type Stage struct {
 	Copies []Copy
 	// Mount references in this stage.
 	Mounts []Mount
+	// Labels set via LABEL instructions in this stage.
+	Labels map[string]string
 }
 
 // BuildOptions controls how a Containerfile is parsed.
@@ -159,7 +163,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 			stageIndex = -1
 		}
 
-		copies, mounts, err := parseStageRefs(s, stageNames)
+		stage, err := parseStage(s, pullspecs[index], stageNames)
 		if err != nil {
 			return res, err
 		}
@@ -172,15 +176,10 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 			base = resolvedBase
 		}
 		aliasToBase[s.Name] = base
+		stage.BaseRef = baseRef
+		stage.Index = stageIndex
 
-		res = append(res, Stage{
-			Alias:   s.Name,
-			Base:    base,
-			BaseRef: baseRef,
-			Index:   stageIndex,
-			Copies:  copies,
-			Mounts:  mounts,
-		})
+		res = append(res, stage)
 	}
 
 	return res, nil
@@ -216,8 +215,8 @@ func resolvePullspecs(stages []imagebuilder.Stage) ([]string, error) {
 	return res, nil
 }
 
-// parseStageRefs parses the AST for the passed imagebuilder.Stage and
-// returns slices of Copy and Mount structs found in the stage.
+// parseStage parses the AST for the passed imagebuilder.Stage and returns a
+// Stage struct with its copies, mounts, and labels populated.
 //
 // A COPY command is builder-type if the "--from" flag is specified and it copies from
 // a builder stage or directly from an image.
@@ -225,9 +224,10 @@ func resolvePullspecs(stages []imagebuilder.Stage) ([]string, error) {
 // Uses the passed previous stageNames to specify whether references are to a stage
 // or directly to an image.
 // WARNING: named contexts in the Containerfile are not supported
-func parseStageRefs(s imagebuilder.Stage, stageNames []string) ([]Copy, []Mount, error) {
+func parseStage(s imagebuilder.Stage, pullspec string, stageNames []string) (Stage, error) {
 	copies := make([]Copy, 0)
 	mounts := make([]Mount, 0)
+	labels := make(map[string]string)
 	workdir := ""
 	headingEnv := argsMapToSlice(s.Builder.HeadingArgs)
 	userEnv := argsMapToSlice(s.Builder.Args)
@@ -235,6 +235,11 @@ func parseStageRefs(s imagebuilder.Stage, stageNames []string) ([]Copy, []Mount,
 	// user provided args override the heading ARGs,
 	// so they're appended second to take priority
 	env := append(headingEnv, userEnv...)
+
+	stage := Stage{
+		Alias: s.Name,
+		Base:  pullspec,
+	}
 
 	for _, child := range s.Node.Children {
 		switch child.Value {
@@ -249,7 +254,7 @@ func parseStageRefs(s imagebuilder.Stage, stageNames []string) ([]Copy, []Mount,
 		case "copy":
 			cp, err := parseCopy(child, workdir, env, stageNames)
 			if err != nil {
-				return copies, mounts, err
+				return stage, err
 			}
 
 			if cp != nil {
@@ -259,13 +264,24 @@ func parseStageRefs(s imagebuilder.Stage, stageNames []string) ([]Copy, []Mount,
 		case "run":
 			runMounts, err := parseMounts(child, env, stageNames)
 			if err != nil {
-				return copies, mounts, err
+				return stage, err
 			}
 			mounts = append(mounts, runMounts...)
+
+		case "label":
+			parsed, err := parseLabels(child, env)
+			if err != nil {
+				return stage, err
+			}
+			maps.Copy(labels, parsed)
 		}
 	}
 
-	return copies, mounts, nil
+	stage.Copies = copies
+	stage.Mounts = mounts
+	stage.Labels = labels
+
+	return stage, nil
 }
 
 // isStageRef returns true if ref matches a known stage, either by name or by
@@ -419,4 +435,22 @@ func parseCopy(node *parser.Node, workdir string, env []string, stageNames []str
 	}
 
 	return nil, nil
+}
+
+func parseLabels(node *parser.Node, env []string) (map[string]string, error) {
+	labels := make(map[string]string)
+	curr := node.Next
+	for curr != nil && curr.Next != nil {
+		key, err := imagebuilder.ProcessWord(curr.Value, env)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrParse, err)
+		}
+		val, err := imagebuilder.ProcessWord(curr.Next.Value, env)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrParse, err)
+		}
+		labels[key] = val
+		curr = curr.Next.Next
+	}
+	return labels, nil
 }

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -78,8 +78,15 @@ const (
 	MountTypeSSH
 )
 
-// A builder or final stage in a Containerfile
-// TODO: encase this in a containerfile struct?
+// Containerfile is a parsed representation of a Containerfile (Dockerfile),
+// containing all build stages in order.
+type Containerfile struct {
+	// Stages in the containerfile, in order. The last stage is the final
+	// (output) stage.
+	Stages []Stage
+}
+
+// A builder or final stage in a Containerfile.
 type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final.
 	Alias string
@@ -116,12 +123,12 @@ var ErrParse = errors.New("error while parsing containerfile")
 
 // Parse reads a Containerfile from the passed reader and uses the passed
 // BuildOptions to parse the Containerfile into stages.
-func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
+func Parse(reader io.Reader, opts BuildOptions) (Containerfile, error) {
 	res := make([]Stage, 0)
 
 	node, err := imagebuilder.ParseDockerfile(reader)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrParse, err)
+		return Containerfile{}, fmt.Errorf("%w: %w", ErrParse, err)
 	}
 
 	// TODO: At this stage, Buildah code takes into account OS and ARCH CLI args
@@ -134,20 +141,20 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 	builder := imagebuilder.NewBuilder(opts.Args)
 	rawStages, err := imagebuilder.NewStages(node, builder)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrParse, err)
+		return Containerfile{}, fmt.Errorf("%w: %w", ErrParse, err)
 	}
 
 	if opts.Target != "" {
 		stagesTargeted, ok := rawStages.ThroughTarget(opts.Target)
 		if !ok {
-			return nil, fmt.Errorf("%w: %s", ErrTargetNotFound, opts.Target)
+			return Containerfile{}, fmt.Errorf("%w: %s", ErrTargetNotFound, opts.Target)
 		}
 		rawStages = stagesTargeted
 	}
 
 	pullspecs, err := resolvePullspecs(rawStages)
 	if err != nil {
-		return nil, err
+		return Containerfile{}, err
 	}
 	stageNames := make([]string, 0)
 	// maps stage alias to root base pullspec (resolved through chain)
@@ -165,7 +172,7 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 
 		stage, err := parseStage(s, pullspecs[index], stageNames)
 		if err != nil {
-			return res, err
+			return Containerfile{Stages: res}, err
 		}
 
 		baseRef := pullspecs[index]
@@ -177,12 +184,13 @@ func Parse(reader io.Reader, opts BuildOptions) ([]Stage, error) {
 		}
 		aliasToBase[s.Name] = base
 		stage.BaseRef = baseRef
+		stage.Base = base
 		stage.Index = stageIndex
 
 		res = append(res, stage)
 	}
 
-	return res, nil
+	return Containerfile{Stages: res}, nil
 }
 
 // argsMapToSlice returns the contents of a map[string]string as a slice of keys

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -458,6 +458,7 @@ func parseCopy(node *parser.Node, workdir string, env []string, stageNames []str
 
 func parseLabels(node *parser.Node, env []string) (map[string]string, error) {
 	labels := make(map[string]string)
+	// iterate over two nodes at the same time - key and value
 	curr := node.Next
 	for curr != nil && curr.Next != nil {
 		key, err := imagebuilder.ProcessWord(curr.Value, env)

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/konflux-ci/capo/pkg/buildargs"
 	"github.com/openshift/imagebuilder"
 	"github.com/openshift/imagebuilder/dockerfile/parser"
 )
@@ -108,8 +109,16 @@ type Stage struct {
 
 // BuildOptions controls how a Containerfile is parsed.
 type BuildOptions struct {
-	// Build arguments passed to buildah for the build
+	// Build arguments passed to buildah for the build.
+	// Environment variable resolution for bare KEY args (without =) must be
+	// done before passing args here (see buildargs.ReadBuildArg).
 	Args map[string]string
+
+	// Path to the build arg file to parse for args.
+	// Bare KEY lines (without =) in the file inherit from the host
+	// environment, matching buildah semantics.
+	BuildArgFilePath string
+
 	// Target stage of the buildah build
 	Target string
 }
@@ -126,6 +135,15 @@ var ErrParse = errors.New("error while parsing containerfile")
 func Parse(reader io.Reader, opts BuildOptions) (Containerfile, error) {
 	res := make([]Stage, 0)
 
+	args := opts.Args
+	if opts.BuildArgFilePath != "" {
+		fileArgs, err := buildargs.ParseBuildArgFile(opts.BuildArgFilePath)
+		if err != nil {
+			return Containerfile{}, fmt.Errorf("parsing build-arg-file: %w", err)
+		}
+		args = buildargs.MergeBuildArgs(fileArgs, opts.Args)
+	}
+
 	node, err := imagebuilder.ParseDockerfile(reader)
 	if err != nil {
 		return Containerfile{}, fmt.Errorf("%w: %w", ErrParse, err)
@@ -138,7 +156,7 @@ func Parse(reader io.Reader, opts BuildOptions) (Containerfile, error) {
 	// but I'm keeping this here as a guideline.
 	// https://github.com/containers/buildah/blob/main/imagebuildah/build.go#L431
 
-	builder := imagebuilder.NewBuilder(opts.Args)
+	builder := imagebuilder.NewBuilder(args)
 	rawStages, err := imagebuilder.NewStages(node, builder)
 	if err != nil {
 		return Containerfile{}, fmt.Errorf("%w: %w", ErrParse, err)

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -181,16 +181,11 @@ func Parse(reader io.Reader, opts BuildOptions) (Containerfile, error) {
 	for index, s := range rawStages {
 		stageNames = append(stageNames, s.Name)
 
-		isFinal := index == len(rawStages)-1
+		alias := s.Name
 		stageIndex := index
-		if isFinal {
-			s.Name = FinalStage
+		if index == len(rawStages)-1 {
+			alias = FinalStage
 			stageIndex = -1
-		}
-
-		stage, err := parseStage(s, pullspecs[index], stageNames)
-		if err != nil {
-			return Containerfile{Stages: res}, err
 		}
 
 		baseRef := pullspecs[index]
@@ -200,10 +195,12 @@ func Parse(reader io.Reader, opts BuildOptions) (Containerfile, error) {
 		if resolvedBase, isChained := aliasToBase[baseRef]; isChained {
 			base = resolvedBase
 		}
-		aliasToBase[s.Name] = base
-		stage.BaseRef = baseRef
-		stage.Base = base
-		stage.Index = stageIndex
+		aliasToBase[alias] = base
+
+		stage, err := parseStage(s, alias, base, baseRef, stageIndex, stageNames)
+		if err != nil {
+			return Containerfile{Stages: res}, err
+		}
 
 		res = append(res, stage)
 	}
@@ -242,15 +239,12 @@ func resolvePullspecs(stages []imagebuilder.Stage) ([]string, error) {
 }
 
 // parseStage parses the AST for the passed imagebuilder.Stage and returns a
-// Stage struct with its copies, mounts, and labels populated.
+// Stage.
 //
-// A COPY command is builder-type if the "--from" flag is specified and it copies from
-// a builder stage or directly from an image.
-// A Mount is extracted from RUN --mount instructions that specify a "from" option.
-// Uses the passed previous stageNames to specify whether references are to a stage
-// or directly to an image.
+// Uses the passed previous stageNames to classify whether COPY --from and
+// RUN --mount references point to a stage or directly to an image.
 // WARNING: named contexts in the Containerfile are not supported
-func parseStage(s imagebuilder.Stage, pullspec string, stageNames []string) (Stage, error) {
+func parseStage(s imagebuilder.Stage, alias, base, baseRef string, index int, stageNames []string) (Stage, error) {
 	copies := make([]Copy, 0)
 	mounts := make([]Mount, 0)
 	labels := make(map[string]string)
@@ -261,11 +255,6 @@ func parseStage(s imagebuilder.Stage, pullspec string, stageNames []string) (Sta
 	// user provided args override the heading ARGs,
 	// so they're appended second to take priority
 	env := append(headingEnv, userEnv...)
-
-	stage := Stage{
-		Alias: s.Name,
-		Base:  pullspec,
-	}
 
 	for _, child := range s.Node.Children {
 		switch child.Value {
@@ -280,7 +269,7 @@ func parseStage(s imagebuilder.Stage, pullspec string, stageNames []string) (Sta
 		case "copy":
 			cp, err := parseCopy(child, workdir, env, stageNames)
 			if err != nil {
-				return stage, err
+				return Stage{}, err
 			}
 
 			if cp != nil {
@@ -290,24 +279,28 @@ func parseStage(s imagebuilder.Stage, pullspec string, stageNames []string) (Sta
 		case "run":
 			runMounts, err := parseMounts(child, env, stageNames)
 			if err != nil {
-				return stage, err
+				return Stage{}, err
 			}
 			mounts = append(mounts, runMounts...)
 
 		case "label":
 			parsed, err := parseLabels(child, env)
 			if err != nil {
-				return stage, err
+				return Stage{}, err
 			}
 			maps.Copy(labels, parsed)
 		}
 	}
 
-	stage.Copies = copies
-	stage.Mounts = mounts
-	stage.Labels = labels
-
-	return stage, nil
+	return Stage{
+		Alias:   alias,
+		Base:    base,
+		BaseRef: baseRef,
+		Index:   index,
+		Copies:  copies,
+		Mounts:  mounts,
+		Labels:  labels,
+	}, nil
 }
 
 // isStageRef returns true if ref matches a known stage, either by name or by

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -731,7 +731,7 @@ func TestParse(t *testing.T) {
 		},
 		"multiple labels on one line": {
 			containerfile: `FROM quay.io/rhel:9
-							LABEL version=1.0 vendor="Red Hat"`,
+							LABEL "version"=1.0 vendor="Red Hat"`,
 			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   FinalStage,
@@ -741,6 +741,22 @@ func TestParse(t *testing.T) {
 					Copies:  []Copy{},
 					Mounts:  []Mount{},
 					Labels:  map[string]string{"version": "1.0", "vendor": "Red Hat"},
+				},
+			}},
+		},
+		"multiline label": {
+			containerfile: `FROM quay.io/rhel:9
+							LABEL description="multi-line \
+label test"`,
+			expected: Containerfile{Stages: []Stage{
+				{
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"description": "multi-line label test"},
 				},
 			}},
 		},

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -4,6 +4,8 @@ package containerfile
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -956,5 +958,177 @@ func TestParse(t *testing.T) {
 				t.Errorf("Parse() result mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func writeBuildArgFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "build-args")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing build arg file: %v", err)
+	}
+	return path
+}
+
+func TestParseBuildArgFromFile(t *testing.T) {
+	t.Parallel()
+	argFile := writeBuildArgFile(t, "IMAGE=docker.io/library/alpine:3.20\n")
+
+	containerfile := `ARG IMAGE
+					   FROM ${IMAGE}`
+
+	expected := Containerfile{Stages: []Stage{
+		{
+			Alias:  FinalStage,
+			Base:   "docker.io/library/alpine:3.20",
+			Copies: []Copy{},
+			Mounts: []Mount{},
+		},
+	}}
+
+	actual, err := Parse(strings.NewReader(containerfile), BuildOptions{
+		BuildArgFilePath: argFile,
+	})
+	if err != nil {
+		t.Fatalf("Parsing failed: %v", err)
+	}
+	if diff := cmp.Diff(expected, actual, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseBuildArgCLIOverridesFile(t *testing.T) {
+	t.Parallel()
+	argFile := writeBuildArgFile(t, "TAG=file-tag\n")
+
+	containerfile := `ARG TAG
+					   FROM docker.io/library/alpine:${TAG}`
+
+	expected := Containerfile{Stages: []Stage{
+		{
+			Alias:  FinalStage,
+			Base:   "docker.io/library/alpine:cli-tag",
+			Copies: []Copy{},
+			Mounts: []Mount{},
+		},
+	}}
+
+	actual, err := Parse(strings.NewReader(containerfile), BuildOptions{
+		BuildArgFilePath: argFile,
+		Args:             map[string]string{"TAG": "cli-tag"},
+	})
+	if err != nil {
+		t.Fatalf("Parsing failed: %v", err)
+	}
+	if diff := cmp.Diff(expected, actual, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseBuildArgEnvResolution(t *testing.T) {
+	t.Setenv("MY_TAG", "envtag")
+
+	argFile := writeBuildArgFile(t, "MY_TAG\n")
+
+	containerfile := `ARG MY_TAG
+					   FROM docker.io/library/alpine:${MY_TAG}`
+
+	expected := Containerfile{Stages: []Stage{
+		{
+			Alias:  FinalStage,
+			Base:   "docker.io/library/alpine:envtag",
+			Copies: []Copy{},
+			Mounts: []Mount{},
+		},
+	}}
+
+	actual, err := Parse(strings.NewReader(containerfile), BuildOptions{
+		BuildArgFilePath: argFile,
+	})
+	if err != nil {
+		t.Fatalf("Parsing failed: %v", err)
+	}
+	if diff := cmp.Diff(expected, actual, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseBuildArgFileEmptyValueStaysEmpty(t *testing.T) {
+	t.Setenv("MY_TAG", "fromenv")
+
+	argFile := writeBuildArgFile(t, "MY_TAG=\n")
+
+	containerfile := `ARG MY_TAG=default
+					   FROM scratch
+					   LABEL tag=$MY_TAG`
+
+	expected := Containerfile{Stages: []Stage{
+		{
+			Alias:  FinalStage,
+			Base:   "scratch",
+			Copies: []Copy{},
+			Mounts: []Mount{},
+			Labels: map[string]string{"tag": ""},
+		},
+	}}
+
+	actual, err := Parse(strings.NewReader(containerfile), BuildOptions{
+		BuildArgFilePath: argFile,
+	})
+	if err != nil {
+		t.Fatalf("Parsing failed: %v", err)
+	}
+	if diff := cmp.Diff(expected, actual, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseBuildArgFileNotFound(t *testing.T) {
+	t.Parallel()
+	containerfile := `FROM scratch`
+
+	_, err := Parse(strings.NewReader(containerfile), BuildOptions{
+		BuildArgFilePath: "/nonexistent/path/build-args",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent build arg file, got nil")
+	}
+}
+
+func TestParseBuildArgMergeWithEnv(t *testing.T) {
+	t.Setenv("C", "from-env-c")
+
+	// File: A=from-file, B= (explicit empty), C (bare key → inherits from env)
+	argFile := writeBuildArgFile(t, "A=from-file\nB=\nC\n")
+
+	containerfile := `ARG A
+					   ARG B
+					   ARG C
+					   FROM scratch
+					   LABEL a=$A b=$B c=$C`
+
+	expected := Containerfile{Stages: []Stage{
+		{
+			Alias:  FinalStage,
+			Base:   "scratch",
+			Copies: []Copy{},
+			Mounts: []Mount{},
+			Labels: map[string]string{
+				"a": "from-file",
+				"b": "from-cli",
+				"c": "from-env-c",
+			},
+		},
+	}}
+
+	actual, err := Parse(strings.NewReader(containerfile), BuildOptions{
+		BuildArgFilePath: argFile,
+		Args:             map[string]string{"B": "from-cli"},
+	})
+	if err != nil {
+		t.Fatalf("Parsing failed: %v", err)
+	}
+	if diff := cmp.Diff(expected, actual, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -979,10 +979,12 @@ func TestParseBuildArgFromFile(t *testing.T) {
 
 	expected := Containerfile{Stages: []Stage{
 		{
-			Alias:  FinalStage,
-			Base:   "docker.io/library/alpine:3.20",
-			Copies: []Copy{},
-			Mounts: []Mount{},
+			Alias:   FinalStage,
+			Base:    "docker.io/library/alpine:3.20",
+			BaseRef: "docker.io/library/alpine:3.20",
+			Index:   -1,
+			Copies:  []Copy{},
+			Mounts:  []Mount{},
 		},
 	}}
 
@@ -1006,10 +1008,12 @@ func TestParseBuildArgCLIOverridesFile(t *testing.T) {
 
 	expected := Containerfile{Stages: []Stage{
 		{
-			Alias:  FinalStage,
-			Base:   "docker.io/library/alpine:cli-tag",
-			Copies: []Copy{},
-			Mounts: []Mount{},
+			Alias:   FinalStage,
+			Base:    "docker.io/library/alpine:cli-tag",
+			BaseRef: "docker.io/library/alpine:cli-tag",
+			Index:   -1,
+			Copies:  []Copy{},
+			Mounts:  []Mount{},
 		},
 	}}
 
@@ -1035,10 +1039,12 @@ func TestParseBuildArgEnvResolution(t *testing.T) {
 
 	expected := Containerfile{Stages: []Stage{
 		{
-			Alias:  FinalStage,
-			Base:   "docker.io/library/alpine:envtag",
-			Copies: []Copy{},
-			Mounts: []Mount{},
+			Alias:   FinalStage,
+			Base:    "docker.io/library/alpine:envtag",
+			BaseRef: "docker.io/library/alpine:envtag",
+			Index:   -1,
+			Copies:  []Copy{},
+			Mounts:  []Mount{},
 		},
 	}}
 
@@ -1064,11 +1070,13 @@ func TestParseBuildArgFileEmptyValueStaysEmpty(t *testing.T) {
 
 	expected := Containerfile{Stages: []Stage{
 		{
-			Alias:  FinalStage,
-			Base:   "scratch",
-			Copies: []Copy{},
-			Mounts: []Mount{},
-			Labels: map[string]string{"tag": ""},
+			Alias:   FinalStage,
+			Base:    "scratch",
+			BaseRef: "scratch",
+			Index:   -1,
+			Copies:  []Copy{},
+			Mounts:  []Mount{},
+			Labels:  map[string]string{"tag": ""},
 		},
 	}}
 
@@ -1109,10 +1117,12 @@ func TestParseBuildArgMergeWithEnv(t *testing.T) {
 
 	expected := Containerfile{Stages: []Stage{
 		{
-			Alias:  FinalStage,
-			Base:   "scratch",
-			Copies: []Copy{},
-			Mounts: []Mount{},
+			Alias:   FinalStage,
+			Base:    "scratch",
+			BaseRef: "scratch",
+			Index:   -1,
+			Copies:  []Copy{},
+			Mounts:  []Mount{},
 			Labels: map[string]string{
 				"a": "from-file",
 				"b": "from-cli",

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseBuiltinArgs(t *testing.T) {
@@ -51,7 +52,7 @@ func TestParseBuiltinArgs(t *testing.T) {
 		t.Fatalf("Parsing failed: %v", err)
 	}
 
-	if diff := cmp.Diff(expected, actual); diff != "" {
+	if diff := cmp.Diff(expected, actual, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("Parse() result mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -709,6 +710,97 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		"single label": {
+			containerfile: `FROM quay.io/rhel:9
+							LABEL version=1.0`,
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+					Labels: map[string]string{"version": "1.0"},
+				},
+			},
+		},
+		"multiple labels on one line": {
+			containerfile: `FROM quay.io/rhel:9
+							LABEL version=1.0 vendor="Red Hat"`,
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+					Labels: map[string]string{"version": "1.0", "vendor": "Red Hat"},
+				},
+			},
+		},
+		"multiple LABEL instructions merge": {
+			containerfile: `FROM quay.io/rhel:9
+							LABEL version=1.0
+							LABEL vendor="Red Hat"`,
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+					Labels: map[string]string{"version": "1.0", "vendor": "Red Hat"},
+				},
+			},
+		},
+		"label with ARG substitution": {
+			containerfile: `ARG VER=2.0
+							FROM quay.io/rhel:9
+							LABEL version=$VER`,
+			buildOptions: BuildOptions{},
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+					Labels: map[string]string{"version": "2.0"},
+				},
+			},
+		},
+		"later label overrides earlier": {
+			containerfile: `FROM quay.io/rhel:9
+							LABEL version=1.0
+							LABEL version=2.0`,
+			expected: []Stage{
+				{
+					Alias:  FinalStage,
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+					Labels: map[string]string{"version": "2.0"},
+				},
+			},
+		},
+		"labels are per-stage": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							LABEL stage=builder
+							FROM scratch
+							LABEL stage=final`,
+			expected: []Stage{
+				{
+					Alias:  "builder",
+					Base:   "quay.io/rhel:9",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+					Labels: map[string]string{"stage": "builder"},
+				},
+				{
+					Alias:  FinalStage,
+					Base:   "scratch",
+					Copies: []Copy{},
+					Mounts: []Mount{},
+					Labels: map[string]string{"stage": "final"},
+				},
+			},
+		},
 		"complex multi-stage with multiple final copies": {
 			containerfile: `FROM docker.io/library/fedora:latest AS builder1
 							FROM docker.io/alpine/helm:latest AS builder2
@@ -844,7 +936,7 @@ func TestParse(t *testing.T) {
 				t.Fatalf("Parsing failed: %v", err)
 			}
 
-			if diff := cmp.Diff(test.expected, actual); diff != "" {
+			if diff := cmp.Diff(test.expected, actual, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Parse() result mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -20,7 +20,7 @@ func TestParseBuiltinArgs(t *testing.T) {
 
 	expectedPullspec := fmt.Sprintf("docker.io/library/alpine:%s", runtime.GOARCH)
 
-	expected := []Stage{
+	expected := Containerfile{Stages: []Stage{
 		{
 			Alias:   "builder",
 			Base:    expectedPullspec,
@@ -43,7 +43,7 @@ func TestParseBuiltinArgs(t *testing.T) {
 			},
 			Mounts: []Mount{},
 		},
-	}
+	}}
 
 	reader := strings.NewReader(containerfile)
 	actual, err := Parse(reader, BuildOptions{})
@@ -62,7 +62,7 @@ func TestParse(t *testing.T) {
 	tests := map[string]struct {
 		containerfile string
 		buildOptions  BuildOptions
-		expected      []Stage
+		expected      Containerfile
 	}{
 		"arg evaluation": {
 			containerfile: `ARG FEDORA_REPO="docker.io/library/fedora"
@@ -76,7 +76,7 @@ func TestParse(t *testing.T) {
 					"FEDORA_TAG": "latest",
 				},
 			},
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/library/alpine:latest",
@@ -106,6 +106,7 @@ func TestParse(t *testing.T) {
 					Mounts: []Mount{},
 				},
 			}},
+		},
 		"alias arg evaluation": {
 			containerfile: `ARG zero=0
 							ARG one=1
@@ -115,7 +116,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder${zero} /usr/bin/oras /usr/bin/oras
 							RUN --mount=from=builder${one},type=bind,src=/usr/bin/binary,dst=/usr/bin/binary ls /usr/bin/binary
 							FROM scratch`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder0",
 					Base:    "docker.io/library/fedora",
@@ -153,6 +154,7 @@ func TestParse(t *testing.T) {
 					},
 				},
 				{Alias: FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1, Copies: []Copy{}, Mounts: []Mount{}},
+				},
 			},
 		},
 		"build target": {
@@ -163,7 +165,7 @@ func TestParse(t *testing.T) {
 			buildOptions: BuildOptions{
 				Target: "builder",
 			},
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   FinalStage,
 					Base:    "docker.io/library/fedora:latest",
@@ -179,7 +181,7 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"copies in final stage only": {
 			containerfile: `FROM docker.io/library/fedora:latest AS builder1
@@ -187,7 +189,7 @@ func TestParse(t *testing.T) {
 							FROM scratch
 							COPY --from=builder1 /usr/bin/oras /usr/bin/oras
 							COPY --from=builder2 /usr/bin/helm /usr/bin/helm`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -225,7 +227,7 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"recursive multi-stage file copy": {
 			containerfile: `FROM docker.io/library/fedora:latest AS builder1
@@ -233,7 +235,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder1 /usr/bin/oras /usr/bin/oras
 							FROM scratch
 							COPY --from=builder2 /usr/bin/oras /usr/bin/oras`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -272,7 +274,7 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"workdir switching - only relative paths": {
 			containerfile: `FROM docker.io/alpine/helm:latest AS builder
@@ -281,7 +283,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder /usr/bin/go ./go
 							WORKDIR bin/
 							COPY --from=builder /usr/bin/capo ../..`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/alpine/helm:latest",
@@ -313,7 +315,7 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"relative paths with workdir switching": {
 			containerfile: `FROM docker.io/alpine/helm:latest AS builder
@@ -329,7 +331,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder /usr/bin/oras .
 							WORKDIR app/
 							COPY --from=builder /usr/bin/mage .`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/alpine/helm:latest",
@@ -403,7 +405,7 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"recursive multi-stage file copy - mixed sources": {
 			containerfile: `FROM docker.io/library/fedora:latest AS builder1
@@ -411,7 +413,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder1 /usr/bin/oras /usr/bin/oras
 							FROM scratch
 							COPY --from=builder2 /usr/bin/oras /usr/bin/helm /app/`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -450,7 +452,7 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"multi-stage directory copy": {
 			containerfile: `FROM docker.io/library/fedora:latest AS builder1
@@ -459,7 +461,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder1 /bin/* /app/
 							FROM scratch
 							COPY --from=builder2 /app/ /app/`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -504,13 +506,13 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"COPY --from numeric stage index": {
 			containerfile: `FROM quay.io/rhel:9
 							FROM scratch
 							COPY --from=0 /usr/bin/binary /usr/bin/binary`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "0",
 					Base:    "quay.io/rhel:9",
@@ -534,13 +536,13 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"COPY --from numeric index with named stage": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							FROM scratch
 							COPY --from=0 /usr/bin/binary /usr/bin/binary`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder",
 					Base:    "quay.io/rhel:9",
@@ -564,12 +566,12 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"COPY --from numeric index out of bounds is external image": {
 			containerfile: `FROM quay.io/rhel:9
 							COPY --from=5 /usr/bin/binary /usr/bin/binary`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   FinalStage,
 					Base:    "quay.io/rhel:9",
@@ -585,12 +587,12 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"RUN --mount=from external image": {
 			containerfile: `FROM quay.io/rhel:9
 							RUN --mount=type=bind,from=quay.io/tools:1,src=/bin/tool,dst=/tmp/tool /tmp/tool --version`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   FinalStage,
 					Base:    "quay.io/rhel:9",
@@ -601,13 +603,13 @@ func TestParse(t *testing.T) {
 						{FromRaw: "quay.io/tools:1", Pullspec: "quay.io/tools:1"},
 					},
 				},
-			},
+			}},
 		},
 		"RUN --mount=from builder stage": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							FROM scratch
 							RUN --mount=type=bind,from=builder,src=/app,dst=/app ls /app`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder",
 					Base:    "quay.io/rhel:9",
@@ -626,13 +628,13 @@ func TestParse(t *testing.T) {
 						{FromRaw: "builder"},
 					},
 				},
-			},
+			}},
 		},
 		"RUN --mount=from numeric stage index": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							FROM scratch
 							RUN --mount=type=bind,from=0,src=/app,dst=/app ls /app`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder",
 					Base:    "quay.io/rhel:9",
@@ -651,20 +653,20 @@ func TestParse(t *testing.T) {
 						{FromRaw: "0"},
 					},
 				},
-			},
+			}},
 		},
 		"duplicate stage names": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							FROM quay.io/fedora:42 AS builder
 							FROM scratch
 							COPY --from=builder /app /app`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{Alias: "builder", Base: "quay.io/rhel:9", BaseRef: "quay.io/rhel:9", Index: 0, Copies: []Copy{}, Mounts: []Mount{}},
 				{Alias: "builder", Base: "quay.io/fedora:42", BaseRef: "quay.io/fedora:42", Index: 1, Copies: []Copy{}, Mounts: []Mount{}},
 				{Alias: FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1, Copies: []Copy{
 					{From: "builder", Sources: []string{"/app"}, Destination: "/app", Type: CopyTypeBuilder},
 				}, Mounts: []Mount{}},
-			},
+			}},
 		},
 		"COPY source paths are normalized to absolute clean paths": {
 			containerfile: `FROM docker.io/library/alpine:latest AS builder
@@ -672,7 +674,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder relative/auntie/jane /dest1
 							COPY --from=builder /foo//bar /dest2
 							COPY --from=builder /foo/baz/../bar /dest3`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/library/alpine:latest",
@@ -708,98 +710,112 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"single label": {
 			containerfile: `FROM quay.io/rhel:9
 							LABEL version=1.0`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
-					Alias:  FinalStage,
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
-					Labels: map[string]string{"version": "1.0"},
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"version": "1.0"},
 				},
-			},
+			}},
 		},
 		"multiple labels on one line": {
 			containerfile: `FROM quay.io/rhel:9
 							LABEL version=1.0 vendor="Red Hat"`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
-					Alias:  FinalStage,
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
-					Labels: map[string]string{"version": "1.0", "vendor": "Red Hat"},
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"version": "1.0", "vendor": "Red Hat"},
 				},
-			},
+			}},
 		},
 		"multiple LABEL instructions merge": {
 			containerfile: `FROM quay.io/rhel:9
 							LABEL version=1.0
 							LABEL vendor="Red Hat"`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
-					Alias:  FinalStage,
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
-					Labels: map[string]string{"version": "1.0", "vendor": "Red Hat"},
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"version": "1.0", "vendor": "Red Hat"},
 				},
-			},
+			}},
 		},
 		"label with ARG substitution": {
 			containerfile: `ARG VER=2.0
 							FROM quay.io/rhel:9
 							LABEL version=$VER`,
 			buildOptions: BuildOptions{},
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
-					Alias:  FinalStage,
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
-					Labels: map[string]string{"version": "2.0"},
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"version": "2.0"},
 				},
-			},
+			}},
 		},
 		"later label overrides earlier": {
 			containerfile: `FROM quay.io/rhel:9
 							LABEL version=1.0
 							LABEL version=2.0`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
-					Alias:  FinalStage,
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
-					Labels: map[string]string{"version": "2.0"},
+					Alias:   FinalStage,
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   -1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"version": "2.0"},
 				},
-			},
+			}},
 		},
 		"labels are per-stage": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							LABEL stage=builder
 							FROM scratch
 							LABEL stage=final`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
-					Alias:  "builder",
-					Base:   "quay.io/rhel:9",
-					Copies: []Copy{},
-					Mounts: []Mount{},
-					Labels: map[string]string{"stage": "builder"},
+					Alias:   "builder",
+					Base:    "quay.io/rhel:9",
+					BaseRef: "quay.io/rhel:9",
+					Index:   0,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"stage": "builder"},
 				},
 				{
-					Alias:  FinalStage,
-					Base:   "scratch",
-					Copies: []Copy{},
-					Mounts: []Mount{},
-					Labels: map[string]string{"stage": "final"},
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies:  []Copy{},
+					Mounts:  []Mount{},
+					Labels:  map[string]string{"stage": "final"},
 				},
-			},
+			}},
 		},
 		"complex multi-stage with multiple final copies": {
 			containerfile: `FROM docker.io/library/fedora:latest AS builder1
@@ -809,7 +825,7 @@ func TestParse(t *testing.T) {
 							COPY --from=builder1 /lib/libc.so /lib/libc.so
 							COPY --from=builder2 /tools/ /usr/bin/
 							COPY --from=builder2 /usr/bin/helm /usr/bin/helm`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -860,7 +876,7 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"chained stages resolve base through chain": {
 			containerfile: `FROM docker.io/library/fedora:latest AS parent
@@ -868,7 +884,7 @@ func TestParse(t *testing.T) {
 							FROM child AS grandchild
 							FROM scratch
 							COPY --from=grandchild /app /app`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{
 					Alias:   "parent",
 					Base:    "docker.io/library/fedora:latest",
@@ -903,14 +919,14 @@ func TestParse(t *testing.T) {
 					},
 					Mounts: []Mount{},
 				},
-			},
+			}},
 		},
 		"run with mount is parsed correctly": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							FROM scratch
 							RUN --mount=type=bind,from=builder,src=/app,dst=/app ls /app
 							RUN --mount=type=cache,from=quay.io/builder,src=/cache,dst=/cache ls /cache`,
-			expected: []Stage{
+			expected: Containerfile{Stages: []Stage{
 				{Alias: "builder", Base: "quay.io/rhel:9", BaseRef: "quay.io/rhel:9", Index: 0, Copies: []Copy{}, Mounts: []Mount{}},
 				{Alias: FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1, Copies: []Copy{}, Mounts: []Mount{
 					{
@@ -924,7 +940,7 @@ func TestParse(t *testing.T) {
 					},
 				}},
 			},
-		},
+		}},
 	}
 
 	for name, test := range tests {

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -108,12 +108,12 @@ func (testCase *TestCase) run(t *testing.T, scanner *Scanner, buildahBinary stri
 		return err
 	}
 
-	stages, err := containerfile.Parse(strings.NewReader(testCase.TestImage.ContainerfileContent), containerfile.BuildOptions{})
+	cf, err := containerfile.Parse(strings.NewReader(testCase.TestImage.ContainerfileContent), containerfile.BuildOptions{})
 	if err != nil {
 		return err
 	}
 
-	result, err := scanner.Scan(stages)
+	result, err := scanner.Scan(cf)
 	if err != nil {
 		return err
 	}
@@ -1990,12 +1990,12 @@ func TestIntegrationScanErrors(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			stages, err := containerfile.Parse(strings.NewReader(tc.ContainerfileContent), containerfile.BuildOptions{})
+			cf, err := containerfile.Parse(strings.NewReader(tc.ContainerfileContent), containerfile.BuildOptions{})
 			if err != nil {
 				t.Fatalf("Failed to parse containerfile: %v", err)
 			}
 
-			_, err = scanner.Scan(stages)
+			_, err = scanner.Scan(cf)
 			if !errors.Is(err, tc.ExpectedError) {
 				t.Fatalf("expected %v, got: %v", tc.ExpectedError, err)
 			}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -66,7 +66,7 @@ func Probe(opts ProbeOpts, client storageclient.Client) (BuildMetadata, error) {
 		meta.Image.Digest = digest.String()
 	}
 
-	stages, err := containerfile.Parse(
+	cf, err := containerfile.Parse(
 		opts.Containerfile,
 		containerfile.BuildOptions{
 			Args:   opts.Args,
@@ -77,7 +77,7 @@ func Probe(opts ProbeOpts, client storageclient.Client) (BuildMetadata, error) {
 		return meta, fmt.Errorf("%w: %w", ErrParseContainerfile, err)
 	}
 
-	reachable := reachableStages(stages)
+	reachable := reachableStages(cf.Stages)
 
 	baseImages, err := resolveBaseImages(client, reachable)
 	if err != nil {

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -194,23 +194,23 @@ func checkUnsupportedFeatures(stages []containerfile.Stage) error {
 // Returns a PackageMetadata struct containing packages and their origin information
 // for resolution by Mobster.
 func (s *Scanner) Scan(
-	stages []containerfile.Stage,
+	cf containerfile.Containerfile,
 ) (PackageMetadata, error) {
-	if err := checkUnsupportedFeatures(stages); err != nil {
+	if err := checkUnsupportedFeatures(cf.Stages); err != nil {
 		return PackageMetadata{}, err
 	}
 
 	res := PackageMetadata{
 		Packages: make([]PackageMetadataItem, 0),
 	}
-	s.logger.Debug("parsed containerfile stages", "stages", stages)
+	s.logger.Debug("parsed containerfile stages", "stages", cf.Stages)
 
-	digests, err := getImageDigests(s.sclient, stages)
+	digests, err := getImageDigests(s.sclient, cf.Stages)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
 
-	roots, externals, err := getPackageSources(s.sclient, stages, digests)
+	roots, externals, err := getPackageSources(s.sclient, cf.Stages, digests)
 	if err != nil {
 		return PackageMetadata{}, err
 	}


### PR DESCRIPTION
Added parsing of labels from containerfiles so our parser can fully replace `dockerfile-json` in konflux-build-cli. 

I also decided to encapsulate the parsed stages into a `Containerfile` struct for easier future expandability.

Also adjusted build arg parsing so that args from environement variables work as expected.