### PR TITLE
Fix codecov.yml: standardize coverage config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,32 +1,18 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: false
 
 coverage:
-  precision: 2
-  round: down
-  range: "50...100"
-
   status:
     project:
       default:
         target: auto
         threshold: 1%
+        informational: true
     patch:
       default:
-        target: auto
-        threshold: 1%
-
-ignore:
-  - "testdata/**"
-  - "docs/**"
-  - "internal/testutils/**"
-
-flags:
-  unit-tests:
-    carryforward: true
-  integration-tests:
-    carryforward: true
+        target: 80%
+        informational: true
 
 comment:
-  layout: "reach,diff,flags,files"
-  behavior: default
+  layout: "reach,diff,flags,files,footer"
+  require_changes: true


### PR DESCRIPTION
## Summary

Updates `codecov.yml` to Konflux standard coverage configuration:
- CI gate disabled (`require_ci_to_pass: false`)
- Patch coverage target: 80% (informational - won't block CI)
- Project coverage target: auto with 1% threshold (informational)
- Comment only on coverage changes

Part of [KFLUXDP-1020](https://redhat.atlassian.net/browse/KFLUXDP-1020) - Konflux Codecov Rollout

Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXDP-1020]: https://redhat.atlassian.net/browse/KFLUXDP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ