### PR TITLE
chore: standardize codecov coverage config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: false
+  require_ci_to_pass: true
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,17 @@ coverage:
         target: 80%
         informational: true
 
+ignore:
+  - "testdata/**"
+  - "docs/**"
+  - "internal/testutils/**"
+
+flags:
+  unit-tests:
+    carryforward: true
+  integration-tests:
+    carryforward: true
+
 comment:
   layout: "reach,diff,flags,files,footer"
   require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,32 +1,18 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: false
 
 coverage:
-  precision: 2
-  round: down
-  range: "50...100"
-
   status:
     project:
       default:
         target: auto
         threshold: 1%
+        informational: true
     patch:
       default:
-        target: auto
-        threshold: 1%
-
-ignore:
-  - "testdata/**"
-  - "docs/**"
-  - "internal/testutils/**"
-
-flags:
-  unit-tests:
-    carryforward: true
-  integration-tests:
-    carryforward: true
+        target: 80%
+        informational: true
 
 comment:
-  layout: "reach,diff,flags,files"
-  behavior: default
+  layout: "reach,diff,flags,files,footer"
+  require_changes: true


### PR DESCRIPTION
## Summary

Updates `codecov.yml` to Konflux standard coverage configuration:
- Preserves existing CI gate setting (`require_ci_to_pass: true`)
- Patch coverage target: 80% (informational - won't block CI)
- Project coverage target: auto with 1% threshold (informational)
- Preserved ignore patterns (testdata, docs, testutils)
- Preserved flags carryforward for unit-tests and integration-tests
- Comment only on coverage changes

### Why 80% patch target?

The 80% patch coverage target is an org-wide standard being rolled out across all konflux-ci repositories as part of [KFLUXDP-1020](https://redhat.atlassian.net/browse/KFLUXDP-1020). It is set to `informational: true`, meaning it will **never block CI or prevent merging** — it only provides visibility into coverage trends on new/changed code. Teams can adjust the target in future PRs if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXDP-1020]: https://redhat.atlassian.net/browse/KFLUXDP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ