### PR TITLE
fix(ISV-7284): detect and reject duplicate stage aliases in Containerfile

### DIFF
--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -273,7 +273,7 @@ func TestProbe(t *testing.T) {
 		},
 		// buildprobe accepts duplicate aliases to match konflux-build-cli, where
 		// findMatchingStages returns all stages with the same name (no error):
-		// https://github.com/konflux-ci/konflux-build-cli/blob/main/pkg/commands/build.go#L2298
+		// https://github.com/konflux-ci/konflux-build-cli/blob/1d6a8e2/pkg/commands/build.go#L2298
 		"duplicate stage names reports both base images": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							COPY . .

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -271,8 +271,9 @@ func TestProbe(t *testing.T) {
 				ExtraImages: []Image{},
 			},
 		},
-		// The following test exists to match inconsistent behaviour in buildah:
-		// https://github.com/containers/buildah/issues/6731
+		// buildprobe accepts duplicate aliases to match konflux-build-cli, where
+		// findMatchingStages returns all stages with the same name (no error):
+		// https://github.com/konflux-ci/konflux-build-cli/blob/main/pkg/commands/build.go#L2298
 		"duplicate stage names reports both base images": {
 			containerfile: `FROM quay.io/rhel:9 AS builder
 							COPY . .

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -169,7 +169,7 @@ func setupStore() (storage.Store, error) {
 func checkUnsupportedFeatures(stages []containerfile.Stage) error {
 	seenAliases := make(map[string]bool)
 	for _, stage := range stages {
-		if stage.Alias != containerfile.FinalStage && seenAliases[stage.Alias] {
+		if stage.Index != -1 && seenAliases[stage.Alias] {
 			return fmt.Errorf(
 				"stage alias %q is used more than once: %w",
 				stage.Alias, ErrDuplicateAlias,

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -94,6 +94,12 @@ var ErrOCIConfig = errors.New("[ERR_OCI_CONFIG] failed to get OCI image config")
 var ErrSBOMScan = errors.New("[ERR_SBOM_SCAN] SBOM scan failed")
 var ErrUnsupportedMount = errors.New("[ERR_UNSUPPORTED_MOUNT] unsupported mount type")
 
+// ErrDuplicateAlias is returned when two stages in a Containerfile share
+// the same alias. Buildah behavior for duplicate aliases is undefined
+// (see https://github.com/containers/buildah/issues/6731), so capo skips
+// builder content identification to avoid producing incorrect results.
+var ErrDuplicateAlias = errors.New("[ERR_DUPLICATE_ALIAS] duplicate stage alias")
+
 // Scanner exposes methods used for scanning of buildah image builds, assigning
 // image origins to SBOM packages present in a built image.
 type Scanner struct {
@@ -161,7 +167,16 @@ func setupStore() (storage.Store, error) {
 }
 
 func checkUnsupportedFeatures(stages []containerfile.Stage) error {
+	seenAliases := make(map[string]bool)
 	for _, stage := range stages {
+		if stage.Alias != containerfile.FinalStage && seenAliases[stage.Alias] {
+			return fmt.Errorf(
+				"stage alias %q is used more than once: %w",
+				stage.Alias, ErrDuplicateAlias,
+			)
+		}
+		seenAliases[stage.Alias] = true
+
 		for _, mount := range stage.Mounts {
 			if mount.MountType == containerfile.MountTypeBind && mount.FromRaw != "" {
 				return fmt.Errorf(

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -1422,6 +1422,20 @@ func TestResolveRelativeDestination(t *testing.T) {
 	}
 }
 
+func TestDuplicateAliasIsRejected(t *testing.T) {
+	t.Parallel()
+	stages := []containerfile.Stage{
+		{Alias: "builder", Base: "quay.io/rhel:9", BaseRef: "quay.io/rhel:9", Index: 0},
+		{Alias: "builder", Base: "quay.io/fedora:42", BaseRef: "quay.io/fedora:42", Index: 1},
+		{Alias: containerfile.FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1},
+	}
+
+	err := checkUnsupportedFeatures(stages)
+	if !errors.Is(err, ErrDuplicateAlias) {
+		t.Fatalf("expected ErrDuplicateAlias, got: %v", err)
+	}
+}
+
 func TestGetPackageSourcesError(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {


### PR DESCRIPTION
Parse() now returns ErrDuplicateAlias when two stages share the same alias. Buildah behavior for duplicates is undefined (containers/buildah#6731), so we fail early instead of silently producing incorrect results. Once buildah defines and stabilizes the behavior, we can remove this guard and adapt accordingly.