### PR TITLE
feat(ISV-7298): support chained stages in buildprobe

### DIFF
--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -160,7 +160,7 @@ func reachableStages(stages []containerfile.Stage) []containerfile.Stage {
 // stageRefs returns all references to other stages from a given stage:
 // the FROM base image and all builder-type COPY --from and RUN --mount refs.
 func stageRefs(stage containerfile.Stage) []string {
-	refs := []string{stage.Base}
+	refs := []string{stage.BaseRef}
 	for _, cp := range stage.Copies {
 		if cp.Type == containerfile.CopyTypeBuilder {
 			refs = append(refs, cp.From)

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -303,6 +303,37 @@ func TestProbe(t *testing.T) {
 				ExtraImages: []Image{},
 			},
 		},
+		// BFS must follow BaseRef (alias) to traverse chained stages,
+		// otherwise the parent stage is unreachable and its extra images are lost
+		"chained stage parent is reachable through chain": {
+			containerfile: `FROM quay.io/rhel:9 AS builder
+							COPY --from=quay.io/tools:1 /bin/tool /usr/bin/tool
+							FROM builder AS child
+							FROM scratch
+							COPY --from=child /app /app`,
+			opts: ProbeOpts{
+				Tag:    "quay.io/image:latest",
+				Target: "",
+				Args:   make(map[string]string),
+			},
+			digests: map[string]digest.Digest{
+				"quay.io/rhel:9":       "rheldigest",
+				"quay.io/tools:1":      "toolsdigest",
+				"quay.io/image:latest": "imagedigest",
+			},
+			expected: BuildMetadata{
+				Image: Image{
+					Pullspec: "quay.io/image:latest",
+					Digest:   "imagedigest",
+				},
+				BaseImages: []Image{
+					{Pullspec: "quay.io/rhel:9", Digest: "rheldigest"},
+				},
+				ExtraImages: []Image{
+					{Pullspec: "quay.io/tools:1", Digest: "toolsdigest"},
+				},
+			},
+		},
 		"unreachable stage is excluded when target is set": {
 			containerfile: `FROM quay.io/alpine:3 AS unreachable
 							RUN echo hello


### PR DESCRIPTION
Use BaseRef instead of Base in stageRefs() so BFS reachability traverses chained stages by alias. Without this, chained stage parents are unreachable and their extra images are lost from output.