### PR TITLE
refactor(ISV-7293): simplify package source generation

### DIFF
--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -87,6 +87,39 @@ type Containerfile struct {
 	Stages []Stage
 }
 
+// Return a stage by its name (alias) or numerical (index) reference. Return
+// nil if it was not found.
+func (c Containerfile) StageByRef(ref string) *Stage {
+	i, err := strconv.Atoi(ref)
+	if err == nil {
+		return c.StageByIndex(i)
+	}
+
+	for _, st := range c.Stages {
+		if st.Alias == ref {
+			return &st
+		}
+	}
+
+	return nil
+}
+
+// Return a stage by its index or nil if the index is out of bounds.
+func (c Containerfile) StageByIndex(index int) *Stage {
+	if index >= 0 && index < len(c.Stages) {
+		return &c.Stages[index]
+	}
+	return nil
+}
+
+// Return a slice of builder stages (all stages except the final).
+func (c Containerfile) BuilderStages() []Stage {
+	if len(c.Stages) == 0 {
+		return nil
+	}
+	return c.Stages[:len(c.Stages)-1]
+}
+
 // A builder or final stage in a Containerfile.
 type Stage struct {
 	// Alias of the builder stage or equal to FinalStage if final.

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -1119,6 +1119,110 @@ func TestParseBuildArgFileNotFound(t *testing.T) {
 	}
 }
 
+func TestStageByRef(t *testing.T) {
+	t.Parallel()
+
+	stages := []Stage{
+		{Alias: "builder", Base: "docker.io/library/fedora:latest", Index: 0},
+		{Alias: "tools", Base: "docker.io/library/alpine:latest", Index: 1},
+		{Alias: FinalStage, Base: "scratch", Index: -1},
+	}
+	cf := Containerfile{Stages: stages}
+
+	tests := map[string]struct {
+		ref      string
+		expected *Stage
+	}{
+		"numeric index": {
+			ref:      "0",
+			expected: &cf.Stages[0],
+		},
+		"alias match": {
+			ref:      "tools",
+			expected: &cf.Stages[1],
+		},
+		"alias not found": {
+			ref:      "nonexistent",
+			expected: nil,
+		},
+		"numeric index out of bounds": {
+			ref:      "99",
+			expected: nil,
+		},
+		"negative numeric string": {
+			ref:      "-1",
+			expected: nil,
+		},
+		"numeric ref prefers index over alias": {
+			ref:      "1",
+			expected: &cf.Stages[1],
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actual := cf.StageByRef(test.ref)
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
+				t.Errorf("StageByRef(%q) mismatch (-want +got):\n%s", test.ref, diff)
+			}
+		})
+	}
+}
+
+func TestStageByIndex(t *testing.T) {
+	t.Parallel()
+
+	stages := []Stage{
+		{Alias: "builder", Base: "docker.io/library/fedora:latest", Index: 0},
+		{Alias: "tools", Base: "docker.io/library/alpine:latest", Index: 1},
+		{Alias: FinalStage, Base: "scratch", Index: -1},
+	}
+	cf := Containerfile{Stages: stages}
+
+	tests := map[string]struct {
+		cf       Containerfile
+		index    int
+		expected *Stage
+	}{
+		"first stage": {
+			cf:       cf,
+			index:    0,
+			expected: &cf.Stages[0],
+		},
+		"last stage": {
+			cf:       cf,
+			index:    2,
+			expected: &cf.Stages[2],
+		},
+		"out of bounds": {
+			cf:       cf,
+			index:    3,
+			expected: nil,
+		},
+		"negative index": {
+			cf:       cf,
+			index:    -1,
+			expected: nil,
+		},
+		"empty stages": {
+			cf:       Containerfile{},
+			index:    0,
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actual := test.cf.StageByIndex(test.index)
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
+				t.Errorf("StageByIndex(%d) mismatch (-want +got):\n%s", test.index, diff)
+			}
+		})
+	}
+}
+
 func TestParseBuildArgMergeWithEnv(t *testing.T) {
 	t.Setenv("C", "from-env-c")
 

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/konflux-ci/capo/internal/sbom"
@@ -205,12 +204,12 @@ func (s *Scanner) Scan(
 	}
 	s.logger.Debug("parsed containerfile stages", "stages", cf.Stages)
 
-	digests, err := getImageDigests(s.sclient, cf.Stages)
+	digests, err := getImageDigests(s.sclient, cf)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
 
-	roots, externals, err := getPackageSources(s.sclient, cf.Stages, digests)
+	roots, externals, err := getPackageSources(s.sclient, cf, digests)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
@@ -238,11 +237,12 @@ func (s *Scanner) Scan(
 // container storage. Chained stages are skipped (their Base is already the
 // root pullspec, resolved by the parser).
 func getImageDigests(
-	storageClient storageclient.Client, stages []containerfile.Stage,
+	storageClient storageclient.Client, cf containerfile.Containerfile,
 ) (map[string]digest.Digest, error) {
 	res := make(map[string]digest.Digest)
 
-	for _, stage := range stages[:len(stages)-1] {
+
+	for _, stage := range cf.BuilderStages() {
 		// This deduplication check covers both duplicate pullspecs across
 		// the containerfile and implicitly skips chained stages (their root
 		// stage already resolved the shared base pullspec).
@@ -260,7 +260,7 @@ func getImageDigests(
 		}
 	}
 
-	for _, stage := range stages {
+	for _, stage := range cf.Stages {
 		for _, cp := range stage.Copies {
 			if cp.Type == containerfile.CopyTypeBuilder {
 				continue
@@ -305,25 +305,13 @@ func attachDigest(pullspec string, dig digest.Digest) (string, error) {
 // to get their default workdirs for relative path resolution in copy destinations.
 func getPackageSources(
 	storageClient storageclient.Client,
-	stages []containerfile.Stage,
+	cf containerfile.Containerfile,
 	digests map[string]digest.Digest,
 ) ([]BuilderPackageSourceRoot, []ExternalPackageSource, error) {
-	// lookup maps for traceSource
-	aliasToIndex := make(map[string]int)
-	indexToStage := make(map[int]*containerfile.Stage)
-	for i := range stages[:len(stages)-1] {
-		st := &stages[i]
-		aliasToIndex[st.Alias] = st.Index
-		indexToStage[st.Index] = st
-		// also map numeric index so COPY --from=<index> resolves
-		// correctly even when stage aliases are present
-		aliasToIndex[strconv.Itoa(i)] = st.Index
-	}
-
 	// mapping of bases used in the containerfile to their initial working
 	// directories
 	baseToWorkdir := make(map[string]string)
-	for _, s := range stages[:len(stages)-1] {
+	for _, s := range cf.BuilderStages() {
 		if storageclient.IsSpecialBase(s.Base) {
 			continue
 		}
@@ -339,7 +327,7 @@ func getPackageSources(
 	// The following code block reads all the builder COPY-ies in the final stage
 	// and recursively traces their content to their respective origins in previous stages.
 	// Builds a map between stage indices and the source paths that originated in them.
-	final := &stages[len(stages)-1]
+	final := &cf.Stages[len(cf.Stages)-1]
 	builderStageAcc := make(map[int][]string)
 	externalAcc := make(map[string][]string)
 
@@ -349,15 +337,16 @@ func getPackageSources(
 			// otherwise the cp.from is a pullspec and it is an external copy
 			// Multiple copies from same external image (multiple COPY instructions referencing same image,
 			// not sources) are grouped under same pullspec.
-			if idx, isBuilder := aliasToIndex[cp.From]; isBuilder {
-				traceSource(source, idx, builderStageAcc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
+			from := cf.StageByRef(cp.From)
+			if from != nil {
+				traceSource(source, from.Index, cf, builderStageAcc, externalAcc, baseToWorkdir)
 			} else {
 				externalAcc[cp.From] = append(externalAcc[cp.From], source)
 			}
 		}
 	}
 
-	roots, err := buildSourceTree(stages, builderStageAcc, aliasToIndex, digests)
+	roots, err := buildSourceTrees(cf, builderStageAcc, digests)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -387,18 +376,17 @@ func getPackageSources(
 	return roots, externals, nil
 }
 
-// buildSourceTree constructs a tree of BuilderPackageSourceRoot (non-chained stages)
+// buildSourceTree constructs trees of BuilderPackageSourceRoot (non-chained stages)
 // with BuilderPackageSourceNode descendants (chained stages) from the traced sources.
-func buildSourceTree(
-	stages []containerfile.Stage,
+func buildSourceTrees(
+	cf containerfile.Containerfile,
 	builderStageAcc map[int][]string,
-	aliasToIndex map[string]int,
 	digests map[string]digest.Digest,
 ) ([]BuilderPackageSourceRoot, error) {
 	rootByIndex := make(map[int]*BuilderPackageSourceRoot)
 	nodeByIndex := make(map[int]*BuilderPackageSourceNode)
 
-	for _, builderStage := range stages[:len(stages)-1] {
+	for _, builderStage := range cf.BuilderStages() {
 		isChained := builderStage.Base != builderStage.BaseRef
 		sources := builderStageAcc[builderStage.Index]
 
@@ -432,22 +420,19 @@ func buildSourceTree(
 			nodeByIndex[builderStage.Index] = node
 
 			// attach to parent — parent can be a root or another node
-			parentIdx := aliasToIndex[builderStage.BaseRef]
-			if parentRoot, ok := rootByIndex[parentIdx]; ok {
+			parentStage := cf.StageByRef(builderStage.BaseRef)
+
+			if parentRoot, ok := rootByIndex[parentStage.Index]; ok {
 				parentRoot.descendants = append(parentRoot.descendants, node)
-			} else if parentNode, ok := nodeByIndex[parentIdx]; ok {
+			} else if parentNode, ok := nodeByIndex[parentStage.Index]; ok {
 				parentNode.descendants = append(parentNode.descendants, node)
 			}
 		}
 	}
 
-	// collect roots in stage order after building the tree (rootByIndex is a map
-	// which does not guarantee iteration order)
 	roots := make([]BuilderPackageSourceRoot, 0, len(rootByIndex))
-	for _, stage := range stages[:len(stages)-1] {
-		if root, ok := rootByIndex[stage.Index]; ok {
-			roots = append(roots, *root)
-		}
+	for _, root := range rootByIndex {
+		roots = append(roots, *root)
 	}
 
 	return roots, nil
@@ -461,13 +446,13 @@ func buildSourceTree(
 func traceSource(
 	source string,
 	stageIndex int,
+	cf containerfile.Containerfile,
 	acc map[int][]string,
-	indexToStage map[int]*containerfile.Stage,
-	aliasToIndex map[string]int,
 	externalAcc map[string][]string,
 	baseToWorkdir map[string]string,
 ) {
-	currStage := indexToStage[stageIndex]
+	currStage := cf.StageByIndex(stageIndex)
+
 	coversMultipleFiles := strings.HasSuffix(source, "/") || strings.ContainsAny(source, "*?[]")
 
 	baseWorkdir, ok := baseToWorkdir[currStage.Base]
@@ -494,9 +479,9 @@ func traceSource(
 				coversMultipleFiles = true
 			}
 			for _, s := range cp.Sources {
-				if nextIdx, ok := aliasToIndex[cp.From]; ok {
-					// builder stage - continue tracing
-					traceSource(s, nextIdx, acc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
+				prevStage := cf.StageByRef(cp.From)
+				if prevStage != nil {
+					traceSource(s, prevStage.Index, cf, acc, externalAcc, baseToWorkdir)
 				} else {
 					// external image - add as external source
 					externalAcc[cp.From] = append(externalAcc[cp.From], s)
@@ -514,8 +499,9 @@ func traceSource(
 	}
 
 	// chained stage — propagate source to parent for builder content scanning
-	if parentIdx, ok := aliasToIndex[currStage.BaseRef]; ok {
-		traceSource(source, parentIdx, acc, indexToStage, aliasToIndex, externalAcc, baseToWorkdir)
+	parentStage := cf.StageByRef(currStage.BaseRef)
+	if parentStage != nil {
+		traceSource(source, parentStage.Index, cf, acc, externalAcc, baseToWorkdir)
 	}
 }
 

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -36,14 +36,14 @@ func configWithWorkdir(workdir string) storageclient.OCIImageConfig {
 func TestGetPackageSources(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
-		stages            []containerfile.Stage
+		cf                containerfile.Containerfile
 		digests           map[string]digest.Digest
 		configs           map[string]storageclient.OCIImageConfig
 		expectedRoots     []BuilderPackageSourceRoot
 		expectedExternals []ExternalPackageSource
 	}{
 		"only external copy in final": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   containerfile.FinalStage,
 					Base:    "scratch",
@@ -58,7 +58,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("abc123"),
 			},
@@ -73,7 +73,7 @@ func TestGetPackageSources(t *testing.T) {
 			},
 		},
 		"copies in final stage only": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -108,7 +108,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("def456"),
 				"docker.io/alpine/helm:latest":    testDigest("ca0789"),
@@ -136,7 +136,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"recursive multi-stage file copy": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -172,7 +172,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("da0012"),
 				"docker.io/alpine/helm:latest":    testDigest("ea0345"),
@@ -200,7 +200,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"recursive multi-stage file copy - mixed sources": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -236,7 +236,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("fa0678"),
 				"docker.io/alpine/helm:latest":    testDigest("5a0901"),
@@ -264,7 +264,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"multi-stage directory copy": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -306,7 +306,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("ba0234"),
 				"docker.io/alpine/helm:latest":    testDigest("0a0567"),
@@ -334,7 +334,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"ignore non-copied content": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -370,7 +370,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("bcd890"),
 				"docker.io/alpine/helm:latest":    testDigest("ef0123"),
@@ -398,7 +398,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"complex multi-stage with multiple final copies": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -446,7 +446,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("a1f456"),
 				"docker.io/alpine/helm:latest":    testDigest("b2f789"),
@@ -474,7 +474,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"wildcard copy in final stage": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/library/fedora:latest",
@@ -495,7 +495,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("a1f456"),
 			},
@@ -514,7 +514,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"wildcard traced through multiple stages": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -548,7 +548,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("a1f456"),
 				"docker.io/alpine/helm:latest":    testDigest("abcdef"),
@@ -576,7 +576,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"mixed wildcards and regular files": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/library/fedora:latest",
@@ -597,7 +597,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("a1f456"),
 			},
@@ -616,7 +616,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"relative destination resolution": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -667,7 +667,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("aaa111"),
 				"docker.io/library/node:latest":   testDigest("bbb222"),
@@ -695,7 +695,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"mixed destinations with workdir variants": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -774,7 +774,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("ccc333"),
 				"docker.io/library/alpine:latest": testDigest("ddd444"),
@@ -802,7 +802,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"multi-stage tracing with workdir in intermediate stage": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -853,7 +853,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("111999"),
 				"docker.io/library/alpine:latest": testDigest("222000"),
@@ -890,7 +890,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"different stages with different base image workdirs": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "go-builder",
 					Base:    "docker.io/library/golang:latest",
@@ -953,7 +953,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/golang:latest":    testDigest("444222"),
 				"docker.io/library/node:latest":      testDigest("555333"),
@@ -999,7 +999,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"numeric index COPY --from in final stage with aliased stages": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/library/fedora:latest",
@@ -1021,7 +1021,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("aaa111"),
 			},
@@ -1040,7 +1040,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"numeric index COPY --from in builder stage with aliased stages": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder1",
 					Base:    "docker.io/library/fedora:latest",
@@ -1076,7 +1076,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("bbb222"),
 				"docker.io/alpine/helm:latest":    testDigest("ccc333"),
@@ -1107,7 +1107,7 @@ func TestGetPackageSources(t *testing.T) {
 			// FROM fedora AS parent    (non-chained, index 0)
 			// FROM parent AS child     (chained, index 1, BaseRef=parent)
 			// FROM scratch             (final, copies from child)
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "parent",
 					Base:    "docker.io/library/fedora:latest",
@@ -1136,7 +1136,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("aa1111"),
 			},
@@ -1165,7 +1165,7 @@ func TestGetPackageSources(t *testing.T) {
 			// FROM fedora AS parent        (non-chained, index 0)
 			// FROM parent AS empty-child   (chained, index 1, BaseRef=parent, no intermediate expected)
 			// FROM scratch                 (final, copies from empty-child)
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "parent",
 					Base:    "docker.io/library/fedora:latest",
@@ -1194,7 +1194,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("bb2222"),
 			},
@@ -1224,7 +1224,7 @@ func TestGetPackageSources(t *testing.T) {
 			// FROM shared AS left     (chained, index 1, BaseRef=shared)
 			// FROM shared AS right    (chained, index 2, BaseRef=shared)
 			// FROM scratch            (final, copies from both left and right)
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "shared",
 					Base:    "docker.io/library/fedora:latest",
@@ -1266,7 +1266,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("cc3333"),
 			},
@@ -1297,7 +1297,7 @@ func TestGetPackageSources(t *testing.T) {
 			expectedExternals: []ExternalPackageSource{},
 		},
 		"external COPY --from in builder stage": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/library/fedora:latest",
@@ -1326,7 +1326,7 @@ func TestGetPackageSources(t *testing.T) {
 						},
 					},
 				},
-			},
+			}},
 			digests: map[string]digest.Digest{
 				"docker.io/library/fedora:latest": testDigest("eee111"),
 				"docker.io/library/external:latest":       testDigest("fff222"),
@@ -1361,7 +1361,7 @@ func TestGetPackageSources(t *testing.T) {
 				test.digests, test.configs,
 			)
 
-			roots, externals, err := getPackageSources(client, test.stages, test.digests)
+			roots, externals, err := getPackageSources(client, test.cf, test.digests)
 			if err != nil {
 				t.Fatalf("getPackageSources returned error: %v", err)
 			}
@@ -1369,6 +1369,7 @@ func TestGetPackageSources(t *testing.T) {
 			rootDiff := cmp.Diff(
 				test.expectedRoots, roots,
 				cmp.AllowUnexported(BuilderPackageSourceRoot{}, BuilderPackageSourceNode{}),
+				cmpopts.SortSlices(func(a, b BuilderPackageSourceRoot) bool { return a.index < b.index }),
 				cmpopts.EquateEmpty(),
 			)
 			if rootDiff != "" {
@@ -1439,13 +1440,13 @@ func TestDuplicateAliasIsRejected(t *testing.T) {
 func TestGetPackageSourcesError(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
-		stages      []containerfile.Stage
+		cf          containerfile.Containerfile
 		digests     map[string]digest.Digest
 		configs     map[string]storageclient.OCIImageConfig
 		expectedErr error
 	}{
 		"GetImageConfig error": {
-			stages: []containerfile.Stage{
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
 					Alias:   "builder",
 					Base:    "docker.io/library/fedora:latest",
@@ -1460,7 +1461,7 @@ func TestGetPackageSourcesError(t *testing.T) {
 					Index:   -1,
 					Copies:  []containerfile.Copy{},
 				},
-			},
+			}},
 			configs:     map[string]storageclient.OCIImageConfig{},
 			expectedErr: ErrOCIConfig,
 		},
@@ -1474,7 +1475,7 @@ func TestGetPackageSourcesError(t *testing.T) {
 				test.digests, test.configs,
 			)
 
-			_, _, err := getPackageSources(client, test.stages, test.digests)
+			_, _, err := getPackageSources(client, test.cf, test.digests)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}


### PR DESCRIPTION
Simplified package source generation by removing the lookup maps and utilizing methods on the containerfile instead.