### PR TITLE
feat(ISV-7293): log resolving process

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -97,6 +97,7 @@ func IntegrationTest() error {
 		"unshare",
 		"go",
 		"test",
+		"-v",
 		"-count=1", // disable test caching
 		"-tags=integration,exclude_graphdriver_btrfs",
 		"./pkg",

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -33,6 +33,8 @@ var ErrMissingStageLabel = errors.New("[ERR_MISSING_STAGE_LABEL] intermediate im
 // specified stage from buildah storage for later syft scanning.
 // Uses buildah stage labels (io.buildah.stage.name) to identify the
 // intermediate image for the given stage alias.
+// If the intermediateContentPath is empty, only builder/external content will
+// be saved.
 func (s *Scanner) getContent(
 	pullspec string,
 	stageAlias string,
@@ -55,18 +57,20 @@ func (s *Scanner) getContent(
 		}
 	}
 
-	// Special bases will have builderImage set as nil
-	intermediate, err := s.getIntermediateContent(
-		builderImage,
-		stageAlias,
-		sources,
-		intermediateContentPath,
-	)
+	if intermediateContentPath != "" {
+		// Special bases will have builderImage set as nil
+		intermediate, err := s.getIntermediateContent(
+			builderImage,
+			stageAlias,
+			sources,
+			intermediateContentPath,
+		)
 
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		s.logContent("intermediate", intermediate, pullspec)
 	}
-	s.logContent("intermediate", intermediate, pullspec)
 
 	if !isSpecialBase {
 		// Only standard bases have builder content. All content in special bases is treated as intermediate.
@@ -86,32 +90,6 @@ func (s *Scanner) logContent(kind string, content []string, pullspec string) {
 	} else {
 		s.logger.Debug("included content", "kind", kind, "content", content, "pullspec", pullspec)
 	}
-}
-
-// getExternalContent extracts content from an external image (COPY --from=image:tag).
-// External images have no intermediate layer — only the image content is extracted.
-func (s *Scanner) getExternalContent(
-	pullspec string,
-	sources []string,
-	contentPath string,
-) error {
-	imgID, err := s.store.Lookup(storageclient.StripTransport(pullspec))
-	if err != nil {
-		return fmt.Errorf("could not find external image %q in buildah storage: %w", pullspec, ErrImageNotFound)
-	}
-
-	img, err := s.store.Image(imgID)
-	if err != nil {
-		return fmt.Errorf("could not find external image %q in buildah storage: %w", pullspec, ErrImageNotFound)
-	}
-
-	content, err := s.getImageContent(img, sources, contentPath)
-	if err != nil {
-		return err
-	}
-
-	s.logContent("external", content, pullspec)
-	return nil
 }
 
 // getDescendantContent extracts intermediate content for a chained stage (node)

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -466,3 +466,40 @@ func checkBuildahVersionFromImage(labels map[string]string) error {
 
 	return nil
 }
+
+func dirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(path, func(_ string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("failed to stat entry: %w", err)
+		}
+		size += info.Size()
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to walk directory %q: %w", path, err)
+	}
+	return size, nil
+}
+
+func formatSize(bytes int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.1fGB", float64(bytes)/float64(gb))
+	case bytes >= mb:
+		return fmt.Sprintf("%.1fMB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.1fKB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%dB", bytes)
+	}
+}

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -1965,24 +1965,6 @@ func TestIntegrationScanErrors(t *testing.T) {
 								   COPY --from=builder /file /file`,
 			ExpectedError: ErrPullspecResolve,
 		},
-		"[RUN --mount] --mount from external image in builder stage": {
-			ContainerfileContent: `FROM localhost/mount-ext-base:latest AS builder
-									COPY go_exp.mod /opt/app3/go.mod
-									RUN --mount=type=bind,from=localhost/mount-ext-source:latest,target=/mnt mkdir -p /opt/app2 && cp /mnt/go.mod /opt/app2/go.mod
-
-									FROM scratch
-									COPY --from=builder /opt /opt`,
-			ExpectedError: ErrUnsupportedMount,
-		},
-		"[RUN --mount] --mount from external image in final stage": {
-			ContainerfileContent: `FROM localhost/mount-ext-base:latest AS builder
-									COPY go_exp.mod /opt/app3/go.mod
-
-									FROM scratch
-									COPY --from=builder /opt /opt
-									RUN --mount=type=bind,from=localhost/mount-ext-source:latest,target=/mnt mkdir -p /opt/app2 && cp /mnt/go.mod /opt/app2/go.mod`,
-			ExpectedError: ErrUnsupportedMount,
-		},
 	}
 
 	scanner, err := NewScanner()

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,6 +21,14 @@ import (
 	"github.com/magefile/mage/sh"
 	"go.podman.io/storage"
 )
+
+func createTestScanner() (*Scanner, error) {
+	return NewScanner(
+		WithLogger(
+			slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		),
+	)
+}
 
 // splitFilesystemTransport splits a filesystem transport reference into the
 // transport prefix and the remaining path+reference. For example
@@ -246,7 +255,6 @@ func cleanUpIntermediateLayers(t *testing.T, store storage.Store) error {
 	}
 	for _, image := range images {
 		if len(image.Names) == 0 {
-			t.Logf("Cleaning up unnamed image %s", image.ID)
 			store.DeleteImage(image.ID, true)
 		}
 	}
@@ -268,11 +276,9 @@ func (buildDef *BuildDefinition) cleanUp(t *testing.T, store storage.Store) erro
 	if storageclient.IsFilesystemTransport(buildDef.Tag) {
 		localPath := filesystemTransportPath(buildDef.Tag)
 		fullPath := filepath.Join(buildDef.ContextDirectory, localPath)
-		t.Logf("Cleaning up filesystem transport artifact %s", fullPath)
 		os.RemoveAll(fullPath)
 		return nil
 	}
-	t.Logf("Cleaning up builder image %s", buildDef.Tag)
 	imageID, err := store.Lookup(buildDef.Tag)
 	if err != nil {
 		t.Logf("Image %s not found, skipping cleanup: %v", buildDef.Tag, err)
@@ -1932,7 +1938,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 	}
-	scanner, err := NewScanner()
+	scanner, err := createTestScanner()
 	if err != nil {
 		t.Fatalf("Failed to create scanner: %+v", err)
 	}
@@ -1967,7 +1973,7 @@ func TestIntegrationScanErrors(t *testing.T) {
 		},
 	}
 
-	scanner, err := NewScanner()
+	scanner, err := createTestScanner()
 	if err != nil {
 		t.Fatalf("Failed to create scanner: %+v", err)
 	}

--- a/pkg/preflight.go
+++ b/pkg/preflight.go
@@ -1,0 +1,87 @@
+// Functions for checking if a containerfile contains any unsupported feature
+// for builder content resolution.
+
+package capo
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/konflux-ci/capo/pkg/containerfile"
+)
+
+var ErrUnsupportedFeature = errors.New(
+	"[ERR_UNSUPPORTED_FEATURES] some features of the containerfile are not supported for builder-content resolution",
+)
+var ErrBuilderIsFinalBase = errors.New("[ERR_BUILDER_FINAL_BASE] builder stage used as final base")
+var ErrMountTypeBind = errors.New("[ERR_MOUNT_TYPE_BIND] RUN --mount with bind type in containerfile")
+
+// ErrDuplicateAlias is returned when two stages in a Containerfile share
+// the same alias. Buildah behavior for duplicate aliases is undefined
+// (see https://github.com/containers/buildah/issues/6731), so capo skips
+// builder content identification to avoid producing incorrect results.
+var ErrDuplicateAlias = errors.New("[ERR_DUPLICATE_ALIAS] duplicate stage alias")
+
+// Check containerfile for unsupported features for builder content resolution.
+func preflightCheck(cf containerfile.Containerfile) error {
+	joined := errors.Join(
+		checkBuilderIsFinalBase(cf),
+		checkDuplicateAlias(cf),
+		checkRunMountTypeBind(cf),
+	)
+	if joined == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %w", ErrUnsupportedFeature, joined)
+}
+
+// Check if any builder stage alias is used in the final stage as the base
+// image.
+func checkBuilderIsFinalBase(cf containerfile.Containerfile) error {
+	if len(cf.Stages) < 2 {
+		return nil
+	}
+
+	final := cf.Stages[len(cf.Stages)-1]
+
+	for i, stage := range cf.BuilderStages() {
+		if final.Base == stage.Alias || final.Base == strconv.Itoa(i) {
+			return fmt.Errorf(
+				"builder stage %q is used as base image of the final stage: %w", stage.Alias, ErrBuilderIsFinalBase,
+			)
+		}
+	}
+
+	return nil
+}
+
+// Check if the containerfile contains two stages with duplicate aliases.
+func checkDuplicateAlias(cf containerfile.Containerfile) error {
+	seenAliases := make(map[string]bool)
+	for _, stage := range cf.Stages {
+		if stage.Index != -1 && seenAliases[stage.Alias] {
+			return fmt.Errorf(
+				"stage alias %q is used more than once: %w",
+				stage.Alias, ErrDuplicateAlias,
+			)
+		}
+		seenAliases[stage.Alias] = true
+	}
+
+	return nil
+}
+
+// Check if the containerfile utilizes a RUN --mount with the bind type.
+func checkRunMountTypeBind(cf containerfile.Containerfile) error {
+	for _, st := range cf.Stages {
+		for _, mount := range st.Mounts {
+			if mount.MountType == containerfile.MountTypeBind && mount.FromRaw != "" {
+				return ErrMountTypeBind
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/preflight.go
+++ b/pkg/preflight.go
@@ -47,7 +47,7 @@ func checkBuilderIsFinalBase(cf containerfile.Containerfile) error {
 	final := cf.Stages[len(cf.Stages)-1]
 
 	for i, stage := range cf.BuilderStages() {
-		if final.Base == stage.Alias || final.Base == strconv.Itoa(i) {
+		if final.BaseRef == stage.Alias || final.BaseRef == strconv.Itoa(i) {
 			return fmt.Errorf(
 				"builder stage %q is used as base image of the final stage: %w", stage.Alias, ErrBuilderIsFinalBase,
 			)

--- a/pkg/preflight.go
+++ b/pkg/preflight.go
@@ -46,8 +46,8 @@ func checkBuilderIsFinalBase(cf containerfile.Containerfile) error {
 
 	final := cf.Stages[len(cf.Stages)-1]
 
-	for i, stage := range cf.BuilderStages() {
-		if final.BaseRef == stage.Alias || final.BaseRef == strconv.Itoa(i) {
+	for _, stage := range cf.BuilderStages() {
+		if final.BaseRef == stage.Alias || final.BaseRef == strconv.Itoa(stage.Index) {
 			return fmt.Errorf(
 				"builder stage %q is used as base image of the final stage: %w", stage.Alias, ErrBuilderIsFinalBase,
 			)

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -1,6 +1,7 @@
 package capo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -606,6 +607,15 @@ func (s *Scanner) scanDescendants(
 		return nil, err
 	}
 
+	if s.logger.Enabled(context.Background(), slog.LevelDebug) {
+		if n, sizeErr := dirSize(intermediateContentPath); sizeErr != nil {
+			s.logger.Warn("failed to calculate content disk usage",
+				"kind", "intermediate (chained)", "alias", node.alias, "error", sizeErr)
+		} else {
+			s.logger.Debug("content disk usage", "kind", "intermediate (chained)", "alias", node.alias, "size", formatSize(n))
+		}
+	}
+
 	if len(intermediate) > 0 {
 		s.logContent("intermediate (chained)", intermediate, node.alias)
 
@@ -680,6 +690,23 @@ func (s *Scanner) scanSource(
 	err = s.getContent(root.pullspec, root.alias, root.sources, builderContentPath, intermediateContentPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if s.logger.Enabled(context.Background(), slog.LevelDebug) {
+		if n, sizeErr := dirSize(builderContentPath); sizeErr != nil {
+			s.logger.Warn("failed to calculate content disk usage",
+				"kind", originType, "pullspec", root.pullspec, "error", sizeErr)
+		} else {
+			s.logger.Debug("content disk usage", "kind", originType, "pullspec", root.pullspec, "size", formatSize(n))
+		}
+		if intermediateContentPath != "" {
+			if n, sizeErr := dirSize(intermediateContentPath); sizeErr != nil {
+				s.logger.Warn("failed to calculate content disk usage",
+					"kind", "intermediate", "pullspec", root.pullspec, "error", sizeErr)
+			} else {
+				s.logger.Debug("content disk usage", "kind", "intermediate", "pullspec", root.pullspec, "size", formatSize(n))
+			}
+		}
 	}
 
 	var intermediatePkgs []sbom.SyftPackage

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -91,13 +91,6 @@ var ErrStorageSetup = errors.New("[ERR_STORAGE_SETUP] failed to set up container
 var ErrPullspecResolve = errors.New("[ERR_PULLSPEC_RESOLVE] failed to resolve pullspec")
 var ErrOCIConfig = errors.New("[ERR_OCI_CONFIG] failed to get OCI image config")
 var ErrSBOMScan = errors.New("[ERR_SBOM_SCAN] SBOM scan failed")
-var ErrUnsupportedMount = errors.New("[ERR_UNSUPPORTED_MOUNT] unsupported mount type")
-
-// ErrDuplicateAlias is returned when two stages in a Containerfile share
-// the same alias. Buildah behavior for duplicate aliases is undefined
-// (see https://github.com/containers/buildah/issues/6731), so capo skips
-// builder content identification to avoid producing incorrect results.
-var ErrDuplicateAlias = errors.New("[ERR_DUPLICATE_ALIAS] duplicate stage alias")
 
 // Scanner exposes methods used for scanning of buildah image builds, assigning
 // image origins to SBOM packages present in a built image.
@@ -165,29 +158,6 @@ func setupStore() (storage.Store, error) {
 	return store, nil
 }
 
-func checkUnsupportedFeatures(stages []containerfile.Stage) error {
-	seenAliases := make(map[string]bool)
-	for _, stage := range stages {
-		if stage.Index != -1 && seenAliases[stage.Alias] {
-			return fmt.Errorf(
-				"stage alias %q is used more than once: %w",
-				stage.Alias, ErrDuplicateAlias,
-			)
-		}
-		seenAliases[stage.Alias] = true
-
-		for _, mount := range stage.Mounts {
-			if mount.MountType == containerfile.MountTypeBind && mount.FromRaw != "" {
-				return fmt.Errorf(
-					"builder content resolution is unsupported for RUN --mount=type=bind: %w",
-					ErrUnsupportedMount,
-				)
-			}
-		}
-	}
-	return nil
-}
-
 // Scan reads the passed containerfile stages, resolves true content origin,
 // extracts relevant content from buildah storage and scans it using syft.
 // Returns a PackageMetadata struct containing packages and their origin information
@@ -195,7 +165,7 @@ func checkUnsupportedFeatures(stages []containerfile.Stage) error {
 func (s *Scanner) Scan(
 	cf containerfile.Containerfile,
 ) (PackageMetadata, error) {
-	if err := checkUnsupportedFeatures(cf.Stages); err != nil {
+	if err := preflightCheck(cf); err != nil {
 		return PackageMetadata{}, err
 	}
 

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -18,13 +18,13 @@ import (
 	"go.podman.io/storage/pkg/reexec"
 )
 
-// BuilderPackageSourceRoot represents a non-chained builder stage or the root of a
-// chain of stages that share the same external base image. Chained stages
-// (FROM parent-alias AS child-alias) are attached as descendants.
-type BuilderPackageSourceRoot struct {
-	// Index of this builder stage.
+// packageSource represents a root package source — either a builder stage
+// (with optional chained descendants) or an external image (COPY --from=image:tag).
+// External roots have external=true, no alias, index 0, and nil descendants.
+type packageSource struct {
+	// Index of this builder stage. Zero for external sources.
 	index int
-	// Stage alias.
+	// Stage alias. Empty for external sources.
 	alias string
 	// Base image pullspec as it appeared in the containerfile.
 	pullspec string
@@ -33,12 +33,15 @@ type BuilderPackageSourceRoot struct {
 	// Paths to content that should be syft-scanned.
 	sources []string
 	// Chained stages that use this stage (or its descendants) as base.
-	descendants []*BuilderPackageSourceNode
+	// Always nil for external sources.
+	descendants []*packageSourceDescendant
+	// True if this root represents an external image source, not a builder stage.
+	external bool
 }
 
-// BuilderPackageSourceNode represents a chained builder stage - a descendant of a
-// BuilderPackageSourceRoot or another BuilderPackageSourceNode.
-type BuilderPackageSourceNode struct {
+// packageSourceDescendant represents a chained builder stage - a descendant of a
+// packageSource or another packageSourceDescendant.
+type packageSourceDescendant struct {
 	// Index of this builder stage.
 	index int
 	// Stage alias.
@@ -46,18 +49,7 @@ type BuilderPackageSourceNode struct {
 	// Paths to content that should be syft-scanned.
 	sources []string
 	// Further chained stages.
-	descendants []*BuilderPackageSourceNode
-}
-
-// ExternalPackageSource is used for external image sources (COPY --from=image:tag)
-// that are not builder stages.
-type ExternalPackageSource struct {
-	// Base image pullspec as it appeared in the COPY --from=pullspec instruction.
-	pullspec string
-	// Base image pullspec with resolved digest.
-	digestBase string
-	// Paths to content that should be syft-scanned.
-	sources []string
+	descendants []*packageSourceDescendant
 }
 
 type PackageMetadata struct {
@@ -179,25 +171,17 @@ func (s *Scanner) Scan(
 		return PackageMetadata{}, err
 	}
 
-	roots, externals, err := getPackageSources(s.sclient, cf, digests)
+	packageSources, err := getPackageSources(s.sclient, cf, digests)
 	if err != nil {
 		return PackageMetadata{}, err
 	}
 
-	for _, root := range roots {
-		rootPkgItems, err := s.scanBuilderStageTree(root)
+	for _, source := range packageSources {
+		items, err := s.scanBuilderStageTree(source)
 		if err != nil {
-			return PackageMetadata{}, fmt.Errorf("failed to scan tree for stage %q: %w", root.alias, err)
+			return PackageMetadata{}, fmt.Errorf("failed to scan source %q: %w", source.pullspec, err)
 		}
-		res.Packages = append(res.Packages, rootPkgItems...)
-	}
-
-	for _, ext := range externals {
-		extPkgItems, err := s.scanExternalSource(ext)
-		if err != nil {
-			return PackageMetadata{}, fmt.Errorf("failed to scan external source %+v: %w", ext, err)
-		}
-		res.Packages = append(res.Packages, extPkgItems...)
+		res.Packages = append(res.Packages, items...)
 	}
 
 	return res, nil
@@ -268,16 +252,16 @@ func attachDigest(pullspec string, dig digest.Digest) (string, error) {
 }
 
 // getPackageSources traces content origins from the final stage through builder
-// stages and returns a tree of BuilderPackageSourceRoot (one per non-chained builder
-// stage) with chained stages attached as BuilderPackageSourceNode descendants.
-// External COPY --from sources are returned separately.
+// stages and returns a slice of packageSource — one per non-chained builder
+// stage (with chained stages attached as packageSourceDescendant descendants)
+// and one per external COPY --from source (with external=true).
 // Uses the passed storageclient.Client to get OCIImageConfigs of base images
 // to get their default workdirs for relative path resolution in copy destinations.
 func getPackageSources(
 	storageClient storageclient.Client,
 	cf containerfile.Containerfile,
 	digests map[string]digest.Digest,
-) ([]BuilderPackageSourceRoot, []ExternalPackageSource, error) {
+) ([]packageSource, error) {
 	// mapping of bases used in the containerfile to their initial working
 	// directories
 	baseToWorkdir := make(map[string]string)
@@ -288,7 +272,7 @@ func getPackageSources(
 
 		cfg, err := storageClient.GetImageConfig(s.Base)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get OCI image config for %q: %w", s.Base, ErrOCIConfig)
+			return nil, fmt.Errorf("failed to get OCI image config for %q: %w", s.Base, ErrOCIConfig)
 		}
 
 		baseToWorkdir[s.Base] = cfg.Config.Workdir
@@ -316,13 +300,11 @@ func getPackageSources(
 		}
 	}
 
-	roots, err := buildSourceTrees(cf, builderStageAcc, digests)
+	packageSources, err := buildSourceTrees(cf, builderStageAcc, digests)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	// construct external package sources
-	externals := make([]ExternalPackageSource, 0)
 	for pullspec, sources := range externalAcc {
 		dig, exists := digests[pullspec]
 		var digestBase string
@@ -330,31 +312,32 @@ func getPackageSources(
 			var err error
 			digestBase, err = attachDigest(storageclient.StripTransport(pullspec), dig)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 		} else {
 			digestBase = pullspec
 		}
 
-		externals = append(externals, ExternalPackageSource{
+		packageSources = append(packageSources, packageSource{
 			pullspec:   pullspec,
 			digestBase: digestBase,
 			sources:    sources,
+			external:   true,
 		})
 	}
 
-	return roots, externals, nil
+	return packageSources, nil
 }
 
-// buildSourceTree constructs trees of BuilderPackageSourceRoot (non-chained stages)
-// with BuilderPackageSourceNode descendants (chained stages) from the traced sources.
+// buildSourceTrees constructs trees of packageSource (non-chained stages)
+// with packageSourceDescendant descendants (chained stages) from the traced sources.
 func buildSourceTrees(
 	cf containerfile.Containerfile,
 	builderStageAcc map[int][]string,
 	digests map[string]digest.Digest,
-) ([]BuilderPackageSourceRoot, error) {
-	rootByIndex := make(map[int]*BuilderPackageSourceRoot)
-	nodeByIndex := make(map[int]*BuilderPackageSourceNode)
+) ([]packageSource, error) {
+	sourceByIndex := make(map[int]*packageSource)
+	nodeByIndex := make(map[int]*packageSourceDescendant)
 
 	for _, builderStage := range cf.BuilderStages() {
 		isChained := builderStage.Base != builderStage.BaseRef
@@ -373,16 +356,16 @@ func buildSourceTrees(
 				digestBase = builderStage.Base
 			}
 
-			root := &BuilderPackageSourceRoot{
+			source := &packageSource{
 				index:      builderStage.Index,
 				alias:      builderStage.Alias,
 				pullspec:   builderStage.Base,
 				digestBase: digestBase,
 				sources:    sources,
 			}
-			rootByIndex[builderStage.Index] = root
+			sourceByIndex[builderStage.Index] = source
 		} else {
-			node := &BuilderPackageSourceNode{
+			node := &packageSourceDescendant{
 				index:   builderStage.Index,
 				alias:   builderStage.Alias,
 				sources: sources,
@@ -392,7 +375,7 @@ func buildSourceTrees(
 			// attach to parent — parent can be a root or another node
 			parentStage := cf.StageByRef(builderStage.BaseRef)
 
-			if parentRoot, ok := rootByIndex[parentStage.Index]; ok {
+			if parentRoot, ok := sourceByIndex[parentStage.Index]; ok {
 				parentRoot.descendants = append(parentRoot.descendants, node)
 			} else if parentNode, ok := nodeByIndex[parentStage.Index]; ok {
 				parentNode.descendants = append(parentNode.descendants, node)
@@ -400,12 +383,12 @@ func buildSourceTrees(
 		}
 	}
 
-	roots := make([]BuilderPackageSourceRoot, 0, len(rootByIndex))
-	for _, root := range rootByIndex {
-		roots = append(roots, *root)
+	sources := make([]packageSource, 0, len(sourceByIndex))
+	for _, source := range sourceByIndex {
+		sources = append(sources, *source)
 	}
 
-	return roots, nil
+	return sources, nil
 }
 
 // traceSource recursively traces a source path through builder stage COPY
@@ -500,17 +483,17 @@ func resolveRelativeDestination(cp containerfile.Copy, baseWorkdir string) strin
 	return filepath.Join(baseWorkdir, cp.Workdir, cp.Destination)
 }
 
-// scanBuilderStageTree scans a BuilderPackageSourceRoot and all its descendants. For the root,
-// both builder base content and intermediate content are extracted. For
-// descendants, only intermediate content is extracted (diffed against parent's
+// scanBuilderStageTree scans a packageSource and all its descendants.
+// For the root, both builder base content and intermediate content are extracted.
+// For descendants, only intermediate content is extracted (diffed against parent's
 // intermediate layer, or builder base if parent has no intermediate).
 func (s *Scanner) scanBuilderStageTree(
-	root BuilderPackageSourceRoot,
+	root packageSource,
 ) ([]PackageMetadataItem, error) {
 	res := make([]PackageMetadataItem, 0)
 
 	// root scan
-	rootItems, err := s.scanSource(root.pullspec, root.alias, root.digestBase, root.sources)
+	rootItems, err := s.scanSource(root)
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +542,7 @@ func (s *Scanner) scanBuilderStageTree(
 // only intermediate content (diffed against diffBase - the nearest ancestor's
 // intermediate image or the builder base image).
 func (s *Scanner) scanDescendants(
-	node *BuilderPackageSourceNode,
+	node *packageSourceDescendant,
 	diffBase *storage.Image,
 	rootDigestBase string,
 ) ([]PackageMetadataItem, error) {
@@ -615,68 +598,30 @@ func (s *Scanner) scanDescendants(
 	return res, nil
 }
 
-// scanExternalSource scans content from an external image (COPY --from=image:tag).
-// External images have no intermediate layer - only the image content is extracted
-// and reported with origin_type "external".
-func (s *Scanner) scanExternalSource(
-	ext ExternalPackageSource,
-) (_ []PackageMetadataItem, err error) {
-	contentPath, err := os.MkdirTemp("", "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w: %w", err, ErrIO)
-	}
-
-	debugMode := os.Getenv("CAPO_DEBUG") != ""
-	if debugMode {
-		s.logger.Debug("external content path", "pullspec", ext.pullspec, "path", contentPath)
-	} else {
-		defer func() {
-			removeErr := os.RemoveAll(contentPath)
-			if err == nil {
-				err = removeErr
-			}
-		}()
-	}
-
-	err = s.getExternalContent(ext.pullspec, ext.sources, contentPath)
-	if err != nil {
-		return nil, err
-	}
-
-	pkgs, err := sbom.SyftScan(contentPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to scan external content: %w: %w", err, ErrSBOMScan)
-	}
-
-	return getPackageMetadata("", ext.digestBase, "external", pkgs, nil), nil
-}
-
 // scanSource extracts content for a stage from buildah storage, scans it
 // with syft, and returns package metadata items.
 func (s *Scanner) scanSource(
-	pullspec string,
-	stageAlias string,
-	digestBase string,
-	sources []string,
+	root packageSource,
 ) (_ []PackageMetadataItem, err error) {
-	// builder content is content that is present in a builder stage base image
 	builderContentPath, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w: %w", err, ErrIO)
 	}
 
-	// intermediate content is content that created in a builder stage base during the build
-	intermediateContentPath, err := os.MkdirTemp("", "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w: %w", err, ErrIO)
+	originType := "external"
+	var intermediateContentPath string
+	if !root.external {
+		originType = "builder"
+		intermediateContentPath, err = os.MkdirTemp("", "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp directory: %w: %w", err, ErrIO)
+		}
 	}
 
-	// if in debug mode, print the paths to saved content
-	// and don't remove the temporary directories
 	debugMode := os.Getenv("CAPO_DEBUG") != ""
 	if debugMode {
-		s.logger.Debug("builder content path", "pullspec", pullspec, "path", builderContentPath)
-		s.logger.Debug("intermediate content path", "pullspec", pullspec, "path", intermediateContentPath)
+		s.logger.Debug("builder content path", "pullspec", root.pullspec, "path", builderContentPath)
+		s.logger.Debug("intermediate content path", "pullspec", root.pullspec, "path", intermediateContentPath)
 	} else {
 		defer func() {
 			removeErr := errors.Join(
@@ -689,14 +634,17 @@ func (s *Scanner) scanSource(
 		}()
 	}
 
-	err = s.getContent(pullspec, stageAlias, sources, builderContentPath, intermediateContentPath)
+	err = s.getContent(root.pullspec, root.alias, root.sources, builderContentPath, intermediateContentPath)
 	if err != nil {
 		return nil, err
 	}
 
-	intermediatePkgs, err := sbom.SyftScan(intermediateContentPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to scan intermediate content: %w: %w", err, ErrSBOMScan)
+	var intermediatePkgs []sbom.SyftPackage
+	if intermediateContentPath != "" {
+		intermediatePkgs, err = sbom.SyftScan(intermediateContentPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan intermediate content: %w: %w", err, ErrSBOMScan)
+		}
 	}
 
 	builderPkgs, err := sbom.SyftScan(builderContentPath)
@@ -705,7 +653,7 @@ func (s *Scanner) scanSource(
 	}
 
 	return getPackageMetadata(
-		stageAlias, digestBase, "builder", builderPkgs, intermediatePkgs,
+		root.alias, root.digestBase, originType, builderPkgs, intermediatePkgs,
 	), nil
 }
 

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -52,6 +52,7 @@ type packageSourceDescendant struct {
 	descendants []*packageSourceDescendant
 }
 
+
 type PackageMetadata struct {
 	Packages []PackageMetadataItem `json:"packages"`
 }
@@ -175,6 +176,7 @@ func (s *Scanner) Scan(
 	if err != nil {
 		return PackageMetadata{}, err
 	}
+	s.logPackageSources(packageSources)
 
 	for _, source := range packageSources {
 		items, err := s.scanBuilderStageTree(source)
@@ -194,7 +196,6 @@ func getImageDigests(
 	storageClient storageclient.Client, cf containerfile.Containerfile,
 ) (map[string]digest.Digest, error) {
 	res := make(map[string]digest.Digest)
-
 
 	for _, stage := range cf.BuilderStages() {
 		// This deduplication check covers both duplicate pullspecs across
@@ -483,6 +484,44 @@ func resolveRelativeDestination(cp containerfile.Copy, baseWorkdir string) strin
 	return filepath.Join(baseWorkdir, cp.Workdir, cp.Destination)
 }
 
+func (s *Scanner) logPackageSources(roots []packageSource) {
+	for _, root := range roots {
+		if root.external {
+			s.logger.Debug("package source: external image",
+				"pullspec", root.pullspec,
+				"digestBase", root.digestBase,
+				"sources", root.sources,
+			)
+		} else {
+			s.logger.Debug("package source: builder stage",
+				"index", root.index,
+				"alias", root.alias,
+				"pullspec", root.pullspec,
+				"digestBase", root.digestBase,
+				"sources", root.sources,
+				"descendants", len(root.descendants),
+			)
+			for _, desc := range root.descendants {
+				s.logPackageSourceDescendant(desc, root.alias, 1)
+			}
+		}
+	}
+}
+
+func (s *Scanner) logPackageSourceDescendant(node *packageSourceDescendant, parentAlias string, depth int) {
+	s.logger.Debug("package source: descendant stage",
+		"depth", depth,
+		"index", node.index,
+		"alias", node.alias,
+		"parent", parentAlias,
+		"sources", node.sources,
+		"descendants", len(node.descendants),
+	)
+	for _, child := range node.descendants {
+		s.logPackageSourceDescendant(child, node.alias, depth+1)
+	}
+}
+
 // scanBuilderStageTree scans a packageSource and all its descendants.
 // For the root, both builder base content and intermediate content are extracted.
 // For descendants, only intermediate content is extracted (diffed against parent's
@@ -490,6 +529,8 @@ func resolveRelativeDestination(cp containerfile.Copy, baseWorkdir string) strin
 func (s *Scanner) scanBuilderStageTree(
 	root packageSource,
 ) ([]PackageMetadataItem, error) {
+	s.logger.Debug("starting root scan", "base", root.digestBase, "pullspec", root.pullspec)
+	defer s.logger.Debug("ending root scan", "base", root.digestBase, "pullspec", root.pullspec)
 	res := make([]PackageMetadataItem, 0)
 
 	// root scan
@@ -546,6 +587,8 @@ func (s *Scanner) scanDescendants(
 	diffBase *storage.Image,
 	rootDigestBase string,
 ) ([]PackageMetadataItem, error) {
+	s.logger.Debug("starting descendant scan", "alias", node.alias)
+	defer s.logger.Debug("ending descendant scan", "alias", node.alias)
 	res := make([]PackageMetadataItem, 0)
 
 	intermediateContentPath, err := os.MkdirTemp("", "")

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -39,8 +39,7 @@ func TestGetPackageSources(t *testing.T) {
 		cf                containerfile.Containerfile
 		digests           map[string]digest.Digest
 		configs           map[string]storageclient.OCIImageConfig
-		expectedRoots     []BuilderPackageSourceRoot
-		expectedExternals []ExternalPackageSource
+		expectedRoots []packageSource
 	}{
 		"only external copy in final": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -63,12 +62,12 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": testDigest("abc123"),
 			},
 			configs:       map[string]storageclient.OCIImageConfig{},
-			expectedRoots: []BuilderPackageSourceRoot{},
-			expectedExternals: []ExternalPackageSource{
+			expectedRoots: []packageSource{
 				{
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("abc123")),
 					sources:    []string{"/usr/bin/oras"},
+					external:   true,
 				},
 			},
 		},
@@ -117,7 +116,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -133,7 +132,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/usr/bin/helm"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"recursive multi-stage file copy": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -181,7 +179,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -197,7 +195,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"recursive multi-stage file copy - mixed sources": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -245,7 +242,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -261,7 +258,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/usr/bin/helm"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"multi-stage directory copy": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -315,7 +311,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -331,7 +327,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/app/"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"ignore non-copied content": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -379,7 +374,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -395,7 +390,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/app/"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"complex multi-stage with multiple final copies": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -455,7 +449,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -471,7 +465,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/tools/", "/usr/bin/helm"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"wildcard copy in final stage": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -502,7 +495,7 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder",
@@ -511,7 +504,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/lib/*.so"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"wildcard traced through multiple stages": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -557,7 +549,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -573,7 +565,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/libs/*.so"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"mixed wildcards and regular files": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -604,7 +595,7 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder",
@@ -613,7 +604,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/usr/bin/helm", "/lib/*.so", "/etc/config.txt"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"relative destination resolution": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -676,7 +666,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/library/node:latest":   configWithWorkdir("/var/data"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -692,7 +682,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"mixed destinations with workdir variants": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -783,7 +772,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/library/alpine:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -799,7 +788,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"multi-stage tracing with workdir in intermediate stage": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -864,7 +852,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/alpine:latest": configWithWorkdir("/"),
 				"docker.io/library/ubuntu:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -887,7 +875,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"different stages with different base image workdirs": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -966,7 +953,7 @@ func TestGetPackageSources(t *testing.T) {
 				"registry.example.com/go-runtime:v1": configWithWorkdir("/app"),
 				"registry.example.com/nginx:v1":      configWithWorkdir("/usr/share/nginx/html"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "go-builder",
@@ -996,7 +983,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"numeric index COPY --from in final stage with aliased stages": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -1028,7 +1014,7 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder",
@@ -1037,7 +1023,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{"/usr/bin/app"},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"numeric index COPY --from in builder stage with aliased stages": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -1085,7 +1070,7 @@ func TestGetPackageSources(t *testing.T) {
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 				"docker.io/alpine/helm:latest":    configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder1",
@@ -1101,7 +1086,6 @@ func TestGetPackageSources(t *testing.T) {
 					sources:    []string{},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"chained stages - parent and child cascade": {
 			// FROM fedora AS parent    (non-chained, index 0)
@@ -1143,14 +1127,14 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "parent",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("aa1111")),
 					sources:    []string{"/app/bin"},
-					descendants: []*BuilderPackageSourceNode{
+					descendants: []*packageSourceDescendant{
 						{
 							index:   1,
 							alias:   "child",
@@ -1159,7 +1143,6 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"chained stages - empty child skipped": {
 			// FROM fedora AS parent        (non-chained, index 0)
@@ -1201,14 +1184,14 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "parent",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("bb2222")),
 					sources:    []string{"/usr/bin/tool"},
-					descendants: []*BuilderPackageSourceNode{
+					descendants: []*packageSourceDescendant{
 						{
 							index:   1,
 							alias:   "empty-child",
@@ -1217,7 +1200,6 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"chained stages - diamond dependency": {
 			// FROM fedora AS shared   (non-chained, index 0)
@@ -1273,14 +1255,14 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "shared",
 					pullspec:   "docker.io/library/fedora:latest",
 					digestBase: "docker.io/library/fedora@" + string(testDigest("cc3333")),
 					sources:    []string{"/left/bin", "/right/bin"},
-					descendants: []*BuilderPackageSourceNode{
+					descendants: []*packageSourceDescendant{
 						{
 							index:   1,
 							alias:   "left",
@@ -1294,7 +1276,6 @@ func TestGetPackageSources(t *testing.T) {
 					},
 				},
 			},
-			expectedExternals: []ExternalPackageSource{},
 		},
 		"external COPY --from in builder stage": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -1334,7 +1315,7 @@ func TestGetPackageSources(t *testing.T) {
 			configs: map[string]storageclient.OCIImageConfig{
 				"docker.io/library/fedora:latest": configWithWorkdir("/"),
 			},
-			expectedRoots: []BuilderPackageSourceRoot{
+			expectedRoots: []packageSource{
 				{
 					index:      0,
 					alias:      "builder",
@@ -1342,12 +1323,11 @@ func TestGetPackageSources(t *testing.T) {
 					digestBase: "docker.io/library/fedora@" + string(testDigest("eee111")),
 					sources:    []string{"/app/"},
 				},
-			},
-			expectedExternals: []ExternalPackageSource{
 				{
 					pullspec:   "docker.io/library/external:latest",
 					digestBase: "docker.io/library/external@" + string(testDigest("fff222")),
 					sources:    []string{"/ext/bin"},
+					external:   true,
 				},
 			},
 		},
@@ -1361,28 +1341,24 @@ func TestGetPackageSources(t *testing.T) {
 				test.digests, test.configs,
 			)
 
-			roots, externals, err := getPackageSources(client, test.cf, test.digests)
+			roots, err := getPackageSources(client, test.cf, test.digests)
 			if err != nil {
 				t.Fatalf("getPackageSources returned error: %v", err)
 			}
 
-			rootDiff := cmp.Diff(
+			diff := cmp.Diff(
 				test.expectedRoots, roots,
-				cmp.AllowUnexported(BuilderPackageSourceRoot{}, BuilderPackageSourceNode{}),
-				cmpopts.SortSlices(func(a, b BuilderPackageSourceRoot) bool { return a.index < b.index }),
+				cmp.AllowUnexported(packageSource{}, packageSourceDescendant{}),
+				cmpopts.SortSlices(func(a, b packageSource) bool {
+					if a.external != b.external {
+						return !a.external
+					}
+					return a.index < b.index
+				}),
 				cmpopts.EquateEmpty(),
 			)
-			if rootDiff != "" {
-				t.Errorf("getPackageSources() roots mismatch (-want +got):\n%s", rootDiff)
-			}
-
-			externalDiff := cmp.Diff(
-				test.expectedExternals, externals,
-				cmp.AllowUnexported(ExternalPackageSource{}),
-				cmpopts.EquateEmpty(),
-			)
-			if externalDiff != "" {
-				t.Errorf("getPackageSources() externals mismatch (-want +got):\n%s", externalDiff)
+			if diff != "" {
+				t.Errorf("getPackageSources() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1461,7 +1437,7 @@ func TestGetPackageSourcesError(t *testing.T) {
 				test.digests, test.configs,
 			)
 
-			_, _, err := getPackageSources(client, test.cf, test.digests)
+			_, err := getPackageSources(client, test.cf, test.digests)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"os"
+	"log/slog"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -1565,7 +1567,11 @@ func TestScanPreflightErrors(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			s := &Scanner{}
+			s, _ := NewScanner(
+				WithLogger(
+					slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+				),
+			)
 			_, err := s.Scan(tc.cf)
 
 			for _, expected := range tc.expectErrs {

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -1423,20 +1423,6 @@ func TestResolveRelativeDestination(t *testing.T) {
 	}
 }
 
-func TestDuplicateAliasIsRejected(t *testing.T) {
-	t.Parallel()
-	stages := []containerfile.Stage{
-		{Alias: "builder", Base: "quay.io/rhel:9", BaseRef: "quay.io/rhel:9", Index: 0},
-		{Alias: "builder", Base: "quay.io/fedora:42", BaseRef: "quay.io/fedora:42", Index: 1},
-		{Alias: containerfile.FinalStage, Base: "scratch", BaseRef: "scratch", Index: -1},
-	}
-
-	err := checkUnsupportedFeatures(stages)
-	if !errors.Is(err, ErrDuplicateAlias) {
-		t.Fatalf("expected ErrDuplicateAlias, got: %v", err)
-	}
-}
-
 func TestGetPackageSourcesError(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {
@@ -1481,6 +1467,141 @@ func TestGetPackageSourcesError(t *testing.T) {
 			}
 			if !errors.Is(err, test.expectedErr) {
 				t.Fatalf("expected error wrapping %v, got: %v", test.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestScanPreflightErrors(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		cf         containerfile.Containerfile
+		expectErrs []error
+		rejectErrs []error
+	}{
+		"builder alias used as final base": {
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/golang:1.22",
+					BaseRef: "docker.io/library/golang:1.22",
+					Index:   0,
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "builder",
+					BaseRef: "builder",
+					Index:   -1,
+				},
+			}},
+			expectErrs: []error{ErrUnsupportedFeature, ErrBuilderIsFinalBase},
+			rejectErrs: []error{ErrDuplicateAlias, ErrMountTypeBind},
+		},
+		"builder referenced by numeric index as final base": {
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/golang:1.22",
+					BaseRef: "docker.io/library/golang:1.22",
+					Index:   0,
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "0",
+					BaseRef: "0",
+					Index:   -1,
+				},
+			}},
+			expectErrs: []error{ErrUnsupportedFeature, ErrBuilderIsFinalBase},
+			rejectErrs: []error{ErrDuplicateAlias, ErrMountTypeBind},
+		},
+		"duplicate stage alias": {
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/golang:1.22",
+					BaseRef: "docker.io/library/golang:1.22",
+					Index:   0,
+				},
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/node:20",
+					BaseRef: "docker.io/library/node:20",
+					Index:   1,
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+				},
+			}},
+			expectErrs: []error{ErrUnsupportedFeature, ErrDuplicateAlias},
+			rejectErrs: []error{ErrBuilderIsFinalBase, ErrMountTypeBind},
+		},
+		"bind mount with from": {
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/golang:1.22",
+					BaseRef: "docker.io/library/golang:1.22",
+					Index:   0,
+					Mounts: []containerfile.Mount{
+						{MountType: containerfile.MountTypeBind, FromRaw: "docker.io/library/some-image:latest"},
+					},
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+				},
+			}},
+			expectErrs: []error{ErrUnsupportedFeature, ErrMountTypeBind},
+			rejectErrs: []error{ErrBuilderIsFinalBase, ErrDuplicateAlias},
+		},
+		"multiple preflight errors": {
+			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/golang:1.22",
+					BaseRef: "docker.io/library/golang:1.22",
+					Index:   0,
+				},
+				{
+					Alias:   "builder",
+					Base:    "docker.io/library/node:20",
+					BaseRef: "docker.io/library/node:20",
+					Index:   1,
+				},
+				{
+					Alias:   containerfile.FinalStage,
+					Base:    "builder",
+					BaseRef: "builder",
+					Index:   -1,
+				},
+			}},
+			expectErrs: []error{ErrUnsupportedFeature, ErrBuilderIsFinalBase, ErrDuplicateAlias},
+			rejectErrs: []error{ErrMountTypeBind},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s := &Scanner{}
+			_, err := s.Scan(tc.cf)
+
+			for _, expected := range tc.expectErrs {
+				if !errors.Is(err, expected) {
+					t.Errorf("expected error wrapping %v, got: %v", expected, err)
+				}
+			}
+
+			for _, rejected := range tc.rejectErrs {
+				if errors.Is(err, rejected) {
+					t.Errorf("unexpected error %v in: %v", rejected, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The changes are split into separate commits, I recommend looking at them individually.

# Changes
- Added a few more logs to make resolving more transparent
- Consolidated unsupported feature checks into one place (preflight.go)
- Consolidated builder and external package sources to use just one struct and reuse builder content functions

## Logging
New logs have been added so that we have the logs for:
- The parsed containerfile
- The package sources that will be scanned
- Individual paths that were found and scanned

An example of a logging trace from the diamond integration test:
```
time=2026-06-29T14:05:25.565+02:00 level=DEBUG msg="parsed containerfile stages" stages="[{Alias:shared Base:localhost/diamond-base:latest BaseRef:localhost/diamond-base:latest Index:0 Copies:[] Mounts:[] Labels:map[]} {Alias:left Base:localhost/diamond-base:latest BaseRef:shared Index:1 Copies:[] Mounts:[] Labels:map[]} {Alias:right Base:localhost/diamond-base:latest BaseRef:shared Index:2 Copies:[] Mounts:[] Labels:map[]} {Alias: Base:scratch BaseRef:scratch Index:-1 Copies:[{Sources:[/shared] Destination:/shared From:left Type:0 Workdir:} {Sources:[/left] Destination:/left From:left Type:0 Workdir:} {Sources:[/right] Destination:/right From:right Type:0 Workdir:} {Sources:[/base] Destination:/base From:right Type:0 Workdir:}] Mounts:[] Labels:map[]}]"
time=2026-06-29T14:05:25.567+02:00 level=DEBUG msg="package source: builder stage" index=0 alias=shared pullspec=localhost/diamond-base:latest digestBase=localhost/diamond-base@sha256:6c35aacaab020f62b61258935a9e4cbbd9985e74f4af4447b0cc7f591b7feb9b sources="[/shared /left /right /base]" descendants=2
time=2026-06-29T14:05:25.567+02:00 level=DEBUG msg="package source: descendant stage" depth=1 index=1 alias=left parent=shared sources="[/shared /left]" descendants=0
time=2026-06-29T14:05:25.567+02:00 level=DEBUG msg="package source: descendant stage" depth=1 index=2 alias=right parent=shared sources="[/right /base]" descendants=0
time=2026-06-29T14:05:25.567+02:00 level=DEBUG msg="starting root scan" base=localhost/diamond-base@sha256:6c35aacaab020f62b61258935a9e4cbbd9985e74f4af4447b0cc7f591b7feb9b pullspec=localhost/diamond-base:latest
time=2026-06-29T14:05:25.567+02:00 level=DEBUG msg="found intermediate image" imageID=58234125bcae4e4f9825315e54f1077d527b583a8cd85ed35c1684932e35578f stage=shared
time=2026-06-29T14:05:25.569+02:00 level=DEBUG msg="included content" kind=intermediate content="[shared/ shared/go.mod]" pullspec=localhost/diamond-base:latest
time=2026-06-29T14:05:25.578+02:00 level=DEBUG msg="included content" kind=builder content=[/base] pullspec=localhost/diamond-base:latest
time=2026-06-29T14:05:26.940+02:00 level=DEBUG msg="found intermediate image" imageID=58234125bcae4e4f9825315e54f1077d527b583a8cd85ed35c1684932e35578f stage=shared
time=2026-06-29T14:05:26.940+02:00 level=DEBUG msg="starting descendant scan" alias=left
time=2026-06-29T14:05:26.940+02:00 level=DEBUG msg="found intermediate image" imageID=8e88a6ba95182ffd9b2f67aea854af798378a252ed8628727f685cc6bb26eebd stage=left
time=2026-06-29T14:05:26.941+02:00 level=DEBUG msg="included content" kind="intermediate (chained)" content="[left/ left/go.mod]" pullspec=left
time=2026-06-29T14:05:27.756+02:00 level=DEBUG msg="ending descendant scan" alias=left
time=2026-06-29T14:05:27.756+02:00 level=DEBUG msg="starting descendant scan" alias=right
time=2026-06-29T14:05:27.756+02:00 level=DEBUG msg="found intermediate image" imageID=3f6675d59d958a9af4b4b9cec806cd0d0271a3d0ad234e9bc22c9cfc93627e3a stage=right
time=2026-06-29T14:05:27.758+02:00 level=DEBUG msg="included content" kind="intermediate (chained)" content="[right/ right/go.mod]" pullspec=right
time=2026-06-29T14:05:28.613+02:00 level=DEBUG msg="ending descendant scan" alias=right
time=2026-06-29T14:05:28.613+02:00 level=DEBUG msg="ending root scan" base=localhost/diamond-base@sha256:6c35aacaab020f62b61258935a9e4cbbd9985e74f4af4447b0cc7f591b7feb9b pullspec=localhost/diamond-base:latest
```