### PR TITLE
feat(ISV-7434): parse build contexts

### DIFF
--- a/cmd/buildprobe/main.go
+++ b/cmd/buildprobe/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"github.com/konflux-ci/capo/pkg/buildvars"
 	"github.com/konflux-ci/capo/pkg/probe"
@@ -41,9 +42,12 @@ type args struct {
 	envVars map[string]string
 	// Target stage of the buildah build
 	target string
+	// Named build contexts passed to the build
+	buildContexts map[string]string
 }
 
 var ErrBuildArg = errors.New("invalid build args syntax")
+var ErrBuildContext = errors.New("invalid build context syntax, expected name=value")
 var ErrBuildEnv = errors.New("invalid build env syntax")
 var ErrNoContainerfile = errors.New("containerfile argument is required")
 var ErrNoTag = errors.New("tag argument is required")
@@ -86,6 +90,20 @@ func parseArgs() (args, error) {
 			return nil
 		},
 	)
+	buildContexts := make(map[string]string)
+	flag.Func(
+		"build-context",
+		"Named build context in the form name=value. Can be used multiple times.",
+		func(s string) error {
+			name, value, ok := strings.Cut(s, "=")
+			if !ok || name == "" {
+				return ErrBuildContext
+			}
+			buildContexts[name] = value
+			return nil
+		},
+	)
+
 	target := flag.String(
 		"target",
 		"",
@@ -127,6 +145,7 @@ func parseArgs() (args, error) {
 		target:            *target,
 		buildArgs:         buildArgs,
 		envVars:           cliEnv,
+		buildContexts:     buildContexts,
 	}, nil
 }
 
@@ -159,6 +178,7 @@ func main() {
 		Tag:           args.tag,
 		Args:          args.buildArgs,
 		EnvVars:       args.envVars,
+		BuildContexts: args.buildContexts,
 	}, client)
 	if err != nil {
 		log.Fatalf("Failed to probe build metadata %+v", err)

--- a/cmd/capo/main.go
+++ b/cmd/capo/main.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
+	"strings"
 
 	"github.com/konflux-ci/capo/pkg"
 	"github.com/konflux-ci/capo/pkg/buildvars"
@@ -25,9 +26,12 @@ type args struct {
 	envVars map[string]string
 	// Target stage of the buildah build
 	target string
+	// Named build contexts passed to the build
+	buildContexts map[string]string
 }
 
 var ErrBuildArg = errors.New("invalid build args syntax")
+var ErrBuildContext = errors.New("invalid build context syntax, expected name=value")
 var ErrEnvVar = errors.New("invalid environment variable syntax")
 var ErrNoContainerfile = errors.New("containerfile argument is required")
 var ErrJSONEncode = errors.New("error while encoding package metadata")
@@ -59,6 +63,20 @@ func parseArgs() (args, error) {
 			if err := buildvars.ReadBuildVariable(s, buildEnvVars); err != nil {
 				return ErrEnvVar
 			}
+			return nil
+		},
+	)
+
+	buildContexts := make(map[string]string)
+	flag.Func(
+		"build-context",
+		"Named build context in the form name=value. Can be used multiple times.",
+		func(s string) error {
+			name, value, ok := strings.Cut(s, "=")
+			if !ok || name == "" {
+				return ErrBuildContext
+			}
+			buildContexts[name] = value
 			return nil
 		},
 	)
@@ -95,6 +113,7 @@ func parseArgs() (args, error) {
 		target:            *target,
 		buildArgs:         buildArgs,
 		envVars:           buildEnvVars,
+		buildContexts:     buildContexts,
 	}, nil
 }
 
@@ -102,9 +121,10 @@ func parseArgs() (args, error) {
 // These are used in the containerfile parser.
 func buildOptsFromArgs(args args) containerfile.BuildOptions {
 	return containerfile.BuildOptions{
-		Args:    args.buildArgs,
-		EnvVars: args.envVars,
-		Target:  args.target,
+		Args:          args.buildArgs,
+		EnvVars:       args.envVars,
+		Target:        args.target,
+		BuildContexts: args.buildContexts,
 	}
 }
 

--- a/pkg/containerfile/containerfile.go
+++ b/pkg/containerfile/containerfile.go
@@ -29,6 +29,8 @@ const (
 	CopyTypeBuilder CopyType = iota
 	// CopyTypeExternal indicates a COPY directly from an external image.
 	CopyTypeExternal
+	// CopyTypeContext indicates a COPY from a named context.
+	CopyTypeContext
 )
 
 // A builder-type COPY command in a Containerfile stage.
@@ -157,6 +159,9 @@ type BuildOptions struct {
 
 	// Target stage of the buildah build
 	Target string
+
+	// Build contexts passed to the build.
+	BuildContexts map[string]string
 }
 
 // ErrTargetNotFound is returned when the target stage specified in
@@ -233,7 +238,8 @@ func Parse(reader io.Reader, opts BuildOptions) (Containerfile, error) {
 		}
 		aliasToBase[alias] = base
 
-		stage, err := parseStage(s, alias, base, baseRef, stageIndex, stageNames, opts.EnvVars)
+		contextNames := slices.Collect(maps.Keys(opts.BuildContexts))
+		stage, err := parseStage(s, alias, base, baseRef, stageIndex, stageNames, opts.EnvVars, contextNames)
 		if err != nil {
 			return Containerfile{Stages: res}, err
 		}
@@ -286,6 +292,7 @@ func parseStage(
 	index int,
 	stageNames []string,
 	envVars map[string]string,
+	contextNames []string,
 ) (Stage, error) {
 	copies := make([]Copy, 0)
 	mounts := make([]Mount, 0)
@@ -314,7 +321,7 @@ func parseStage(
 			}
 
 		case "copy":
-			cp, err := parseCopy(child, workdir, env, stageNames)
+			cp, err := parseCopy(child, workdir, env, stageNames, contextNames)
 			if err != nil {
 				return Stage{}, err
 			}
@@ -474,13 +481,11 @@ func normalizeSources(sources []string, env []string) ([]string, error) {
 // Uses the passed env to evaluate arguments in the COPY.
 // Uses the passed previous stage names to evaluate whether this COPY command is from
 // a builder stage or directly from an external image.
-func parseCopy(node *parser.Node, workdir string, env []string, stageNames []string) (*Copy, error) {
+// Uses the passed build context names to determine if the COPY command is
+// copying from a named build context.
+func parseCopy(node *parser.Node, workdir string, env []string,
+	stageNames []string, contextNames []string) (*Copy, error) {
 	for _, fl := range node.Flags {
-		// TODO: When the "--from" flag is included, this is a COPY either from a builder stage,
-		// an external image or a named context. We assume that named contexts aren't used,
-		// as they're not supported in any current Konflux buildah tasks. To resolve this in
-		// the future, we might have to include a --build-context argument to capo (to use the same
-		// syntax as "buildah bud") and skip the copies that copy from these contexts.
 		if !strings.HasPrefix(fl, "--from=") {
 			continue
 		}
@@ -508,9 +513,13 @@ func parseCopy(node *parser.Node, workdir string, env []string, stageNames []str
 			return nil, fmt.Errorf("%w: %w", ErrParse, err)
 		}
 
-		cpType := CopyTypeBuilder
-		if !isStageRef(from, stageNames) {
-			cpType = CopyTypeExternal
+		// Determine if copying from a builder stage, an external image, or a
+		// named context
+		cpType := CopyTypeExternal
+		if slices.Contains(contextNames, from) {
+			cpType = CopyTypeContext
+		} else if isStageRef(from, stageNames) {
+			cpType = CopyTypeBuilder
 		}
 
 		return &Copy{

--- a/pkg/containerfile/containerfile_test.go
+++ b/pkg/containerfile/containerfile_test.go
@@ -1014,6 +1014,51 @@ label test"`,
 				},
 			}},
 		},
+		"COPY from named contexts": {
+			containerfile: `FROM scratch
+							COPY --from=reldir /usr/bin/binary /usr/bin/binary
+							COPY --from=https /usr/bin/binary /usr/bin/binary
+							COPY --from=image /usr/bin/binary /usr/bin/binary`,
+			buildOptions: BuildOptions{
+				Args: map[string]string{
+					"FEDORA_TAG": "latest",
+				},
+				BuildContexts: map[string]string{
+					"reldir": "../dir",
+					"https": "https://example.org/releases/src.tar",
+					"image": "container-image://alpine:3.15",
+				},
+			},
+			expected: Containerfile{Stages: []Stage{
+				{
+					Alias:   FinalStage,
+					Base:    "scratch",
+					BaseRef: "scratch",
+					Index:   -1,
+					Copies: []Copy{
+						{
+							From:        "reldir",
+							Sources:     []string{"/usr/bin/binary"},
+							Destination: "/usr/bin/binary",
+							Type:        CopyTypeContext,
+						},
+						{
+							From:        "https",
+							Sources:     []string{"/usr/bin/binary"},
+							Destination: "/usr/bin/binary",
+							Type:        CopyTypeContext,
+						},
+						{
+							From:        "image",
+							Sources:     []string{"/usr/bin/binary"},
+							Destination: "/usr/bin/binary",
+							Type:        CopyTypeContext,
+						},
+					},
+					Mounts: []Mount{},
+				},
+			}},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -63,6 +63,9 @@ type BuildDefinition struct {
 	// ContextDirectory is the build context path relative to pkg/
 	// (e.g. "../testdata/image_content").
 	ContextDirectory string
+	// Build contexts to pass to the build. Values representing local directory
+	// paths are relative to pkg/
+	BuildContexts map[string]string
 }
 
 // TestCase describes a single integration test: build images, scan, compare results.
@@ -117,7 +120,12 @@ func (testCase *TestCase) run(t *testing.T, scanner *Scanner, buildahBinary stri
 		return err
 	}
 
-	cf, err := containerfile.Parse(strings.NewReader(testCase.TestImage.ContainerfileContent), containerfile.BuildOptions{})
+	cf, err := containerfile.Parse(
+		strings.NewReader(testCase.TestImage.ContainerfileContent),
+		containerfile.BuildOptions{
+			BuildContexts: testCase.TestImage.BuildContexts,
+		},
+	)
 	if err != nil {
 		return err
 	}
@@ -230,6 +238,12 @@ func (buildDef *BuildDefinition) runBuildah(buildahBinary, tag string, saveStage
 	if saveStages {
 		args = append(args, "--save-stages", "--stage-labels")
 	}
+	if buildDef.BuildContexts != nil {
+		for k, v := range buildDef.BuildContexts {
+			args = append(args, "--build-context", fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
 	args = append(args, buildDef.ContextDirectory)
 
 	var buf bytes.Buffer
@@ -1936,6 +1950,17 @@ func TestIntegration(t *testing.T) {
 					},
 				},
 			},
+		},
+		"copying from named build context does not fail": {
+			TestImage: BuildDefinition{
+				ContainerfileContent: `	FROM scratch
+										COPY --from=named go2.mod go2.mod`,
+				ContextDirectory: "../testdata/image_content",
+				BuildContexts: map[string]string {
+					"named": "../testdata/image_content",
+				},
+			},
+			ExpectedResult: PackageMetadata{Packages: []PackageMetadataItem{}},
 		},
 	}
 	scanner, err := createTestScanner()

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -44,6 +44,8 @@ type ProbeOpts struct {
 	Args map[string]string
 	// Environment variables passed to the build
 	EnvVars map[string]string
+	// Named build contexts passed to the build
+	BuildContexts map[string]string
 }
 
 // ErrParseContainerfile is returned when the Containerfile cannot be parsed.
@@ -71,9 +73,10 @@ func Probe(opts ProbeOpts, client storageclient.Client) (BuildMetadata, error) {
 	cf, err := containerfile.Parse(
 		opts.Containerfile,
 		containerfile.BuildOptions{
-			Args:    opts.Args,
-			EnvVars: opts.EnvVars,
-			Target:  opts.Target,
+			Args:          opts.Args,
+			EnvVars:       opts.EnvVars,
+			Target:        opts.Target,
+			BuildContexts: opts.BuildContexts,
 		},
 	)
 	if err != nil {

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -218,17 +218,15 @@ func getImageDigests(
 
 	for _, stage := range cf.Stages {
 		for _, cp := range stage.Copies {
-			if cp.Type == containerfile.CopyTypeBuilder {
-				continue
-			}
+			if cp.Type == containerfile.CopyTypeExternal {
+				if _, ok := res[cp.From]; !ok {
+					dig, err := storageClient.ResolveDigest(cp.From)
+					if err != nil {
+						return res, fmt.Errorf("failed to resolve pullspec %q: %w: %w", cp.From, err, ErrPullspecResolve)
+					}
 
-			if _, ok := res[cp.From]; !ok {
-				dig, err := storageClient.ResolveDigest(cp.From)
-				if err != nil {
-					return res, fmt.Errorf("failed to resolve pullspec %q: %w: %w", cp.From, err, ErrPullspecResolve)
+					res[cp.From] = dig
 				}
-
-				res[cp.From] = dig
 			}
 		}
 	}
@@ -288,6 +286,11 @@ func getPackageSources(
 	externalAcc := make(map[string][]string)
 
 	for _, cp := range final.Copies {
+		// TODO: resolving from named contexts is currently not supported
+		if cp.Type == containerfile.CopyTypeContext {
+			continue
+		}
+
 		for _, source := range cp.Sources {
 			// the copy is builder type only if there's no builder stage with alias equal to the cp.from
 			// otherwise the cp.from is a pullspec and it is an external copy


### PR DESCRIPTION
## Changes
- Added support for parsing COPY commands from named contexts in the `containerfile` package.
- Refactored the `capo` package to not scan or resolve digests of copies from context.