### PR TITLE
fix: image lookup fallback stripping tag from tag+digest references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,12 @@
 module github.com/konflux-ci/capo
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/anchore/syft v1.32.0
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/magefile/mage v1.14.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/openshift/imagebuilder v1.2.19
 	go.podman.io/image/v5 v5.38.0
 	go.podman.io/storage v1.61.0
@@ -31,7 +34,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.50.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.13.0 // indirect
@@ -127,7 +129,6 @@ require (
 	github.com/gohugoio/hashstructure v0.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-containerregistry v0.20.6 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/licensecheck v0.3.1 // indirect
@@ -193,7 +194,6 @@ require (
 	github.com/olekukonko/ll v0.0.9 // indirect
 	github.com/olekukonko/tablewriter v1.0.9 // indirect
 	github.com/onsi/gomega v1.38.2 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.12.0 // indirect

--- a/pkg/content.go
+++ b/pkg/content.go
@@ -37,6 +37,7 @@ var ErrMissingStageLabel = errors.New("[ERR_MISSING_STAGE_LABEL] intermediate im
 // be saved.
 func (s *Scanner) getContent(
 	pullspec string,
+	digestBase string,
 	stageAlias string,
 	sources []string,
 	builderContentPath string,
@@ -49,7 +50,10 @@ func (s *Scanner) getContent(
 		// Special bases are not pullable or resolvable with Lookup
 		imgId, err := s.store.Lookup(storageclient.StripTransport(pullspec))
 		if err != nil {
-			return fmt.Errorf("could not find image %q in buildah storage: %w", pullspec, ErrImageNotFound)
+			imgId, err = s.store.Lookup(storageclient.StripTransport(digestBase))
+			if err != nil {
+				return fmt.Errorf("could not find image %q in buildah storage: %w", pullspec, ErrImageNotFound)
+			}
 		}
 		builderImage, err = s.store.Image(imgId)
 		if err != nil {

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -260,6 +260,37 @@ func normalizePullspec(pullspec string) string {
 	return pullspec
 }
 
+// buildDigestOnlyImage builds a builder image and renames it to a digest-only
+// reference, simulating how buildah stores images pulled from a registry by
+// digest.
+// Returns the digest-only reference (e.g. "localhost/name@sha256:...").
+func buildDigestOnlyImage(t *testing.T, def BuildDefinition, store storage.Store, buildahBinary string) string {
+	t.Helper()
+	if err := def.buildImage(store, buildahBinary, true); err != nil {
+		t.Fatalf("buildDigestOnlyImage: build failed: %v", err)
+	}
+	imgID, err := store.Lookup(def.Tag)
+	if err != nil {
+		t.Fatalf("buildDigestOnlyImage: lookup failed: %v", err)
+	}
+	img, err := store.Image(imgID)
+	if err != nil {
+		t.Fatalf("buildDigestOnlyImage: get image failed: %v", err)
+	}
+	// This avoids splitting on the port colon in "localhost:5000/name:tag".
+	repo := def.Tag
+	if idx := strings.LastIndex(repo, ":"); idx > strings.LastIndex(repo, "/") {
+		repo = repo[:idx]
+	}
+	digestRef := repo + "@" + img.Digest.String()
+	// Simulate buildah: images pulled with tag+digest are stored under digest-only name
+	if err := store.SetNames(imgID, []string{digestRef}); err != nil {
+		t.Fatalf("buildDigestOnlyImage: SetNames failed: %v", err)
+	}
+	t.Cleanup(func() { def := BuildDefinition{Tag: digestRef}; def.cleanUp(t, store) })
+	return digestRef
+}
+
 // cleanUpIntermediateLayers deletes all images without names/tags from the store.
 // This technically cleans more than just intermediate layers, but it shouldn't matter.
 func cleanUpIntermediateLayers(t *testing.T, store storage.Store) error {
@@ -1956,7 +1987,7 @@ func TestIntegration(t *testing.T) {
 				ContainerfileContent: `	FROM scratch
 										COPY --from=named go2.mod go2.mod`,
 				ContextDirectory: "../testdata/image_content",
-				BuildContexts: map[string]string {
+				BuildContexts: map[string]string{
 					"named": "../testdata/image_content",
 				},
 			},
@@ -1981,6 +2012,120 @@ func TestIntegration(t *testing.T) {
 			}
 		})
 	}
+
+}
+
+// TestIntegrationDigestLookup verifies that capo can resolve and scan builder
+// images stored under digest-only names (as buildah does after pulling with a
+// tag+digest ref).
+func TestIntegrationDigestLookup(t *testing.T) {
+	scanner, err := createTestScanner()
+	if err != nil {
+		t.Fatalf("Failed to create scanner: %+v", err)
+	}
+	buildahBinary := getBuildahBinary(t)
+
+	t.Run("Builder base image referenced by digest only", func(t *testing.T) {
+		digestRef := buildDigestOnlyImage(t, BuildDefinition{
+			Tag:                  "localhost/capo-digest-test-builder:latest",
+			ContainerfileContent: "FROM scratch\nCOPY go_syft.mod /opt/go.mod",
+			ContextDirectory:     "../testdata/image_content",
+		}, scanner.store, buildahBinary)
+
+		tc := TestCase{
+			TestImage: BuildDefinition{
+				ContainerfileContent: fmt.Sprintf(`FROM %s as builder
+FROM scratch
+COPY --from=builder /opt/go.mod /opt/go.mod`, digestRef),
+				ContextDirectory: "../testdata/image_content",
+			},
+			ExpectedResult: PackageMetadata{
+				Packages: []PackageMetadataItem{
+					{
+						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
+						OriginType: "builder",
+						Pullspec:   "localhost/capo-digest-test-builder@sha256:dummy",
+						StageAlias: "builder",
+					},
+				},
+			},
+		}
+		normalizeTestCaseTags(&tc)
+		if err := tc.run(t, scanner, buildahBinary); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Builder base image referenced by tag+digest", func(t *testing.T) {
+		builderTag := "localhost/capo-tagdigest-test-builder:v1"
+		digestRef := buildDigestOnlyImage(t, BuildDefinition{
+			Tag:                  builderTag,
+			ContainerfileContent: "FROM scratch\nCOPY go_syft.mod /opt/go.mod",
+			ContextDirectory:     "../testdata/image_content",
+		}, scanner.store, buildahBinary)
+
+		// Reconstruct the tag+digest pullspec from the stored digest-only ref.
+		_, digestSuffix, _ := strings.Cut(digestRef, "@")
+		tagDigestRef := builderTag + "@" + digestSuffix
+
+		tc := TestCase{
+			TestImage: BuildDefinition{
+				ContainerfileContent: fmt.Sprintf(`FROM %s as builder
+FROM scratch
+COPY --from=builder /opt/go.mod /opt/go.mod`, tagDigestRef),
+				ContextDirectory: "../testdata/image_content",
+			},
+			ExpectedResult: PackageMetadata{
+				Packages: []PackageMetadataItem{
+					{
+						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
+						OriginType: "builder",
+						Pullspec:   "localhost/capo-tagdigest-test-builder@sha256:dummy",
+						StageAlias: "builder",
+					},
+				},
+			},
+		}
+		normalizeTestCaseTags(&tc)
+		if err := tc.run(t, scanner, buildahBinary); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Builder base image referenced by tag+digest with port", func(t *testing.T) {
+		builderTag := "localhost:5000/capo-port-test-builder:v1"
+		digestRef := buildDigestOnlyImage(t, BuildDefinition{
+			Tag:                  builderTag,
+			ContainerfileContent: "FROM scratch\nCOPY go_syft.mod /opt/go.mod",
+			ContextDirectory:     "../testdata/image_content",
+		}, scanner.store, buildahBinary)
+
+		_, digestSuffix, _ := strings.Cut(digestRef, "@")
+		tagDigestRef := builderTag + "@" + digestSuffix
+
+		tc := TestCase{
+			TestImage: BuildDefinition{
+				ContainerfileContent: fmt.Sprintf(`FROM %s as builder
+FROM scratch
+COPY --from=builder /opt/go.mod /opt/go.mod`, tagDigestRef),
+				ContextDirectory: "../testdata/image_content",
+			},
+			ExpectedResult: PackageMetadata{
+				Packages: []PackageMetadataItem{
+					{
+						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
+						OriginType: "builder",
+						Pullspec:   "localhost:5000/capo-port-test-builder@sha256:dummy",
+						StageAlias: "builder",
+					},
+				},
+			},
+		}
+		normalizeTestCaseTags(&tc)
+		if err := tc.run(t, scanner, buildahBinary); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 type ErrorTestCase struct {

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -552,7 +552,10 @@ func (s *Scanner) scanBuilderStageTree(
 		// to its builder base image.
 		imgId, err := s.store.Lookup(storageclient.StripTransport(root.pullspec))
 		if err != nil {
-			return nil, fmt.Errorf("could not find image %q in buildah storage: %w", root.pullspec, ErrImageNotFound)
+			imgId, err = s.store.Lookup(storageclient.StripTransport(root.digestBase))
+			if err != nil {
+				return nil, fmt.Errorf("could not find image %q in buildah storage: %w", root.pullspec, ErrImageNotFound)
+			}
 		}
 		builderBaseImage, err := s.store.Image(imgId)
 		if err != nil {
@@ -690,7 +693,10 @@ func (s *Scanner) scanSource(
 		}()
 	}
 
-	err = s.getContent(root.pullspec, root.alias, root.sources, builderContentPath, intermediateContentPath)
+	err = s.getContent(
+		root.pullspec, root.digestBase, root.alias, root.sources,
+		builderContentPath, intermediateContentPath,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storageclient/storageclient.go
+++ b/pkg/storageclient/storageclient.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
+	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/storage"
 	"go.podman.io/storage/pkg/reexec"
 )
@@ -127,17 +128,73 @@ func NewBuildahClient(store storage.Store) Client {
 	}
 }
 
+// LookupImage looks up an image in the store by ref (tag or digest), with
+// a fallback for tag+digest references (name:tag@sha256:...).
+//
+// Background: when buildah pulls a FROM image referenced by tag+digest
+// (name:tag@sha256:...), libimage strips the tag (Docker-spec compatibility)
+// and stores the image under the digest-only name — see
+// https://github.com/containers/buildah/blob/v1.44.0/new.go#L164 and
+// https://github.com/containers/common/blob/a5ccdae8/libimage/pull.go#L118.
+// Stripping the tag when both tag and digest are present is an established
+// Docker convention ("the digest is the sole source of truth") — see
+// https://github.com/containers/common/blob/a5ccdae8/libimage/normalize.go#L103.
+//
+// If the direct lookup fails, tag+digest form is assumed, stripTagFromDigestedRef
+// attempts to strip the tag and the lookup is retried with the digest-only form.
+//
+// Techdebt: short names without a registry prefix (e.g. "FROM alpine") are
+// not resolved — store.Lookup fails and ParseNamed rejects them as
+// non-canonical, so no fallback is applied. Proper fix:
+// use go.podman.io/image/v5/pkg/shortnames.ResolveLocally
+// to read the registries.conf that was active during the preceding buildah build.
+func (c *BuildahClient) lookupImage(ref string) (string, error) {
+	stripped := StripTransport(ref)
+	id, err := c.store.Lookup(stripped)
+	if err != nil {
+		normalized, normErr := stripTagFromDigestedRef(stripped)
+		if normErr != nil {
+			return "", normErr
+		}
+		if normalized != "" {
+			id, err = c.store.Lookup(normalized)
+		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("looking up %q in storage: %w", ref, err)
+	}
+	return id, nil
+}
+func stripTagFromDigestedRef(ref string) (string, error) {
+	named, err := reference.ParseNamed(ref)
+	if err != nil {
+		return "", nil // reference is not canonical
+	}
+	digested, ok := named.(reference.Digested)
+	if !ok {
+		return "", nil
+	}
+	digestOnly, err := reference.WithDigest(reference.TrimNamed(named), digested.Digest())
+	if err != nil {
+		return "", fmt.Errorf("attaching digest to %q: %w", ref, err)
+	}
+	if digestOnly.String() == ref {
+		return "", nil
+	}
+	return digestOnly.String(), nil
+}
+
 // ResolveDigest looks up the given pullspec in the local storage and returns
 // its content digest in the form "sha256:<hex>". Transport prefixes (e.g.
 // "docker://") are stripped before the lookup. The reference can be the
 // image's name or ID.
 func (c *BuildahClient) ResolveDigest(ref string) (digest.Digest, error) {
-	id, err := c.store.Lookup(StripTransport(ref))
+	imgId, err := c.lookupImage(ref)
 	if err != nil {
 		return "", fmt.Errorf("%w %q: %w", ErrPullspecResolve, ref, err)
 	}
 
-	img, err := c.store.Image(id)
+	img, err := c.store.Image(imgId)
 	if err != nil {
 		return "", fmt.Errorf("%w %q: %w", ErrPullspecResolve, ref, err)
 	}
@@ -148,7 +205,7 @@ func (c *BuildahClient) ResolveDigest(ref string) (digest.Digest, error) {
 // Get an OCIImageConfig struct for the passed pullspec via buildah's container
 // storage. The reference can be the image's name or ID.
 func (c *BuildahClient) GetImageConfig(ref string) (OCIImageConfig, error) {
-	imgId, err := c.store.Lookup(StripTransport(ref))
+	imgId, err := c.lookupImage(ref)
 	if err != nil {
 		return OCIImageConfig{}, fmt.Errorf("%w %s: %w", ErrOCIImageConfig, ref, err)
 	}


### PR DESCRIPTION
Buildah stores images pulled with name:tag@sha256:... under the digest-only name name@sha256:... (Docker convention, tag is ignored when digest present). Direct store.Lookup fails for tag+digest refs.

storageclient: lookupImage now strips tag and retries with normalized ref on lookup failure. Used internally by ResolveDigest and GetImageConfig.

content.go/scan.go: use raw s.store.Lookup first with pullspec then with a digestBase fallback. Consolidating functionality into storageclient requires wrapping raw storage ops into sclient first (future refactor).