### PR TITLE
feat(ISV-7437): allow builder stages to be used as final base

### DIFF
--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -695,48 +695,33 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 		},
-		// A builder stage can be used as the final image base (FROM alias_as_base).
-		// When this happens, its base image content becomes the final image's parent
-		// content — externally built, not reported by capo (responsibility of parent
-		// content identification in mobster). However, its intermediate content
-		// (created during THIS build) remains intermediate and should be reported,
-		// because fixing it requires changing this containerfile.
-		// This distinction (parent base vs intermediate of a stage used as final base)
-		// should be verified in mobster as well.
-		"Builder used as final stage base - builder content excluded (parent content), intermediate traced": {
-			SkipTestReason: "[Priority: low/medium] capo does not distinguish builder content from final base content when builder is used as FROM base",
+		// Verify that if a builder stage is used as a base for the final
+		// image, its content is not resolved as builder nor as intermediate.
+		"Builder used as final stage base - builder content excluded": {
 			TestImage: BuildDefinition{
 				Tag: "test-final-uses-builder-base",
 				ContainerfileContent: `FROM localhost/builder1:latest AS builder
 										COPY go_uuid.mod /content/go.mod
-										COPY go_sync.mod /untracked/builder/go.mod
 
 										FROM localhost/builder2:latest AS alias_as_base
 										COPY go_exp.mod /content/go.mod
-										COPY --from=builder /base1a /base1ainparent
 
 										FROM alias_as_base
 										COPY --from=builder /base1 /base1
-										COPY --from=builder /content /content
-										COPY --from=alias_as_base /base1ainparent /base1a
-										COPY --from=alias_as_base /base2 /base2
-										COPY --from=alias_as_base /content /content2`,
+										COPY --from=builder /content /content`,
 				ContextDirectory: "../testdata/image_content",
 			},
 			BuilderImages: []BuildDefinition{
 				{
 					Tag: "localhost/builder1:latest",
 					ContainerfileContent: `FROM scratch
-											COPY go_syft.mod /base1/go.mod
-											COPY go_text.mod /base1a/go.mod
-											COPY go2.mod /untracked/b1/go.mod`,
+											COPY go_syft.mod /base1/go.mod`,
 					ContextDirectory: "../testdata/image_content",
 				},
 				{
 					Tag: "localhost/builder2:latest",
 					ContainerfileContent: `FROM scratch
-											COPY go_sync.mod /base2/go.mod
-											COPY go2.mod /untracked/b2/go.mod`,
+											COPY go_sync.mod /base2/go.mod`,
 					ContextDirectory: "../testdata/image_content",
 				},
 			},
@@ -749,7 +734,52 @@ func TestIntegration(t *testing.T) {
 						StageAlias: "builder",
 					},
 					{
-						PackageURL: "pkg:golang/golang.org/x/text@v0.18.0",
+						PackageURL: "pkg:golang/github.com/google/uuid@v1.6.0",
+						OriginType: "intermediate",
+						Pullspec:   "localhost/builder1@sha256:dummy",
+						StageAlias: "builder",
+					},
+				},
+			},
+		},
+		// WARNING: This test is not specifically "correct", ideally content
+		// copied from builder stage used as final base would not be reported
+		// builder/intermediate at all. This test is here just to catch any
+		// accidental change of behaviour.
+		"Builder used as final stage base - explicit COPY from base stage traced": {
+			TestImage: BuildDefinition{
+				Tag: "test-final-uses-builder-base-with-copy",
+				ContainerfileContent: `FROM localhost/builder1:latest AS builder
+										COPY go_uuid.mod /content/go.mod
+
+										FROM localhost/builder2:latest AS alias_as_base
+										COPY go_exp.mod /content/go.mod
+
+										FROM alias_as_base
+										COPY --from=builder /base1 /base1
+										COPY --from=builder /content /content
+										COPY --from=alias_as_base /base2 /base2
+										COPY --from=alias_as_base /content /content2`,
+				ContextDirectory: "../testdata/image_content",
+			},
+			BuilderImages: []BuildDefinition{
+				{
+					Tag: "localhost/builder1:latest",
+					ContainerfileContent: `FROM scratch
+											COPY go_syft.mod /base1/go.mod`,
+					ContextDirectory: "../testdata/image_content",
+				},
+				{
+					Tag: "localhost/builder2:latest",
+					ContainerfileContent: `FROM scratch
+											COPY go_sync.mod /base2/go.mod`,
+					ContextDirectory: "../testdata/image_content",
+				},
+			},
+			ExpectedResult: PackageMetadata{
+				Packages: []PackageMetadataItem{
+					{
+						PackageURL: "pkg:golang/github.com/anchore/syft@v1.32.0",
 						OriginType: "builder",
 						Pullspec:   "localhost/builder1@sha256:dummy",
 						StageAlias: "builder",
@@ -759,6 +789,12 @@ func TestIntegration(t *testing.T) {
 						OriginType: "intermediate",
 						Pullspec:   "localhost/builder1@sha256:dummy",
 						StageAlias: "builder",
+					},
+					{
+						PackageURL: "pkg:golang/golang.org/x/sync@v0.8.0",
+						OriginType: "builder",
+						Pullspec:   "localhost/builder2@sha256:dummy",
+						StageAlias: "alias_as_base",
 					},
 					{
 						PackageURL: "pkg:golang/golang.org/x/exp@v0.0.0-20240808152545-0cdaa3abc0fa",

--- a/pkg/preflight.go
+++ b/pkg/preflight.go
@@ -6,7 +6,6 @@ package capo
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/konflux-ci/capo/pkg/containerfile"
 )
@@ -14,7 +13,6 @@ import (
 var ErrUnsupportedFeature = errors.New(
 	"[ERR_UNSUPPORTED_FEATURES] some features of the containerfile are not supported for builder-content resolution",
 )
-var ErrBuilderIsFinalBase = errors.New("[ERR_BUILDER_FINAL_BASE] builder stage used as final base")
 var ErrMountTypeBind = errors.New("[ERR_MOUNT_TYPE_BIND] RUN --mount with bind type in containerfile")
 
 // ErrDuplicateAlias is returned when two stages in a Containerfile share
@@ -26,7 +24,6 @@ var ErrDuplicateAlias = errors.New("[ERR_DUPLICATE_ALIAS] duplicate stage alias"
 // Check containerfile for unsupported features for builder content resolution.
 func preflightCheck(cf containerfile.Containerfile) error {
 	joined := errors.Join(
-		checkBuilderIsFinalBase(cf),
 		checkDuplicateAlias(cf),
 		checkRunMountTypeBind(cf),
 	)
@@ -35,26 +32,6 @@ func preflightCheck(cf containerfile.Containerfile) error {
 	}
 
 	return fmt.Errorf("%w: %w", ErrUnsupportedFeature, joined)
-}
-
-// Check if any builder stage alias is used in the final stage as the base
-// image.
-func checkBuilderIsFinalBase(cf containerfile.Containerfile) error {
-	if len(cf.Stages) < 2 {
-		return nil
-	}
-
-	final := cf.Stages[len(cf.Stages)-1]
-
-	for _, stage := range cf.BuilderStages() {
-		if final.BaseRef == stage.Alias || final.BaseRef == strconv.Itoa(stage.Index) {
-			return fmt.Errorf(
-				"builder stage %q is used as base image of the final stage: %w", stage.Alias, ErrBuilderIsFinalBase,
-			)
-		}
-	}
-
-	return nil
 }
 
 // Check if the containerfile contains two stages with duplicate aliases.

--- a/pkg/scan_test.go
+++ b/pkg/scan_test.go
@@ -1457,42 +1457,6 @@ func TestScanPreflightErrors(t *testing.T) {
 		expectErrs []error
 		rejectErrs []error
 	}{
-		"builder alias used as final base": {
-			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
-				{
-					Alias:   "builder",
-					Base:    "docker.io/library/golang:1.22",
-					BaseRef: "docker.io/library/golang:1.22",
-					Index:   0,
-				},
-				{
-					Alias:   containerfile.FinalStage,
-					Base:    "builder",
-					BaseRef: "builder",
-					Index:   -1,
-				},
-			}},
-			expectErrs: []error{ErrUnsupportedFeature, ErrBuilderIsFinalBase},
-			rejectErrs: []error{ErrDuplicateAlias, ErrMountTypeBind},
-		},
-		"builder referenced by numeric index as final base": {
-			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
-				{
-					Alias:   "builder",
-					Base:    "docker.io/library/golang:1.22",
-					BaseRef: "docker.io/library/golang:1.22",
-					Index:   0,
-				},
-				{
-					Alias:   containerfile.FinalStage,
-					Base:    "0",
-					BaseRef: "0",
-					Index:   -1,
-				},
-			}},
-			expectErrs: []error{ErrUnsupportedFeature, ErrBuilderIsFinalBase},
-			rejectErrs: []error{ErrDuplicateAlias, ErrMountTypeBind},
-		},
 		"duplicate stage alias": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
 				{
@@ -1515,7 +1479,7 @@ func TestScanPreflightErrors(t *testing.T) {
 				},
 			}},
 			expectErrs: []error{ErrUnsupportedFeature, ErrDuplicateAlias},
-			rejectErrs: []error{ErrBuilderIsFinalBase, ErrMountTypeBind},
+			rejectErrs: []error{ErrMountTypeBind},
 		},
 		"bind mount with from": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -1536,7 +1500,7 @@ func TestScanPreflightErrors(t *testing.T) {
 				},
 			}},
 			expectErrs: []error{ErrUnsupportedFeature, ErrMountTypeBind},
-			rejectErrs: []error{ErrBuilderIsFinalBase, ErrDuplicateAlias},
+			rejectErrs: []error{ErrDuplicateAlias},
 		},
 		"multiple preflight errors": {
 			cf: containerfile.Containerfile{Stages: []containerfile.Stage{
@@ -1559,7 +1523,7 @@ func TestScanPreflightErrors(t *testing.T) {
 					Index:   -1,
 				},
 			}},
-			expectErrs: []error{ErrUnsupportedFeature, ErrBuilderIsFinalBase, ErrDuplicateAlias},
+			expectErrs: []error{ErrUnsupportedFeature, ErrDuplicateAlias},
 			rejectErrs: []error{ErrMountTypeBind},
 		},
 	}


### PR DESCRIPTION
We can enable builder stages to be used as final bases without changes in capo, because the differences in the SBOM will be minimal and will not affect the CVE remediation process.

## Changes
- Removed the builder stage as final base preflight check
- Unskipped and simplified the test to verify that such content does not resolve to builder/intermediate if not explicitly copied from.
- Added a regression test to verify that such content IS resolved to builder/intermediate if explicitly copied from. 
  - just to make sure that we don't change this behaviour without noticing